### PR TITLE
fix: ResponseEntity Created 반환시 400에러 및 데이터 반환하지 않는 에러 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/base/handler/BaseResponseHandler.java
+++ b/src/main/java/com/bookbla/americano/base/handler/BaseResponseHandler.java
@@ -43,6 +43,7 @@ public class BaseResponseHandler implements ResponseBodyAdvice<Object> {
         if (resolve == null) {
             return body;
         }
+
         if (resolve.is2xxSuccessful()) {
             return new BaseResponse<>(body);
         }

--- a/src/main/java/com/bookbla/americano/domain/test/controller/TestController.java
+++ b/src/main/java/com/bookbla/americano/domain/test/controller/TestController.java
@@ -5,7 +5,6 @@ import com.bookbla.americano.base.exception.BaseExceptionType;
 import com.bookbla.americano.domain.test.controller.dto.request.TestRequestDTO;
 import com.bookbla.americano.domain.test.controller.dto.response.TestResponseDTO;
 import com.bookbla.americano.domain.test.service.TestService;
-
 import java.net.URI;
 import java.util.List;
 import javax.validation.Valid;
@@ -34,7 +33,8 @@ public class TestController {
     @PostMapping("")
     public ResponseEntity<TestResponseDTO> testSave(@RequestBody @Valid TestRequestDTO requestDTO) {
         TestResponseDTO testResponseDTO = testService.test(requestDTO);
-        return ResponseEntity.created(URI.create("/test/" + testResponseDTO.getId())).build();
+        return ResponseEntity.created(URI.create("/test/" + testResponseDTO.getId()))
+                .body(testResponseDTO);
     }
 
     @GetMapping("/error")

--- a/src/main/java/com/bookbla/americano/domain/test/controller/dto/request/TestRequestDTO.java
+++ b/src/main/java/com/bookbla/americano/domain/test/controller/dto/request/TestRequestDTO.java
@@ -5,9 +5,11 @@ import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class TestRequestDTO {
 


### PR DESCRIPTION
## 📄 Summary

>
*  test save 실행 시 400에러가 발생하던 문제 수정 -> 기본생성자 추가
* response에 data가 포함되지 않는 에러 발견 -> created는 URI를 기본 인자로 받음, 따로 body에 반환할 객체를 넣어줌

=> 정상 작동

## 🙋🏻 More

>