### PR TITLE
fix: 개인 질문 생성/수정시 개인 질문도 함께 보내도록 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleCreateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleCreateRequest.java
@@ -39,6 +39,9 @@ public class MemberStyleCreateRequest {
     @NotNull(message = "데이트 스타일이 입력되지 않았습니다.")
     private String dateStyleType;
 
+    @NotNull(message = "개인 질문이 입력되지 않았습니다.")
+    private String memberAsk;
+
     public MemberStyle toMemberStyleWith(Member member) {
         return MemberStyle.builder()
                 .member(member)
@@ -50,5 +53,9 @@ public class MemberStyleCreateRequest {
                 .justFriendType(JustFriendType.from(justFriendType))
                 .dateCostType(DateCostType.from(dateCostType))
                 .build();
+    }
+
+    public String getMemberAsk() {
+        return memberAsk;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleUpdateRequest.java
@@ -37,6 +37,9 @@ public class MemberStyleUpdateRequest {
     @NotNull(message = "데이트 스타일이 입력되지 않았습니다.")
     private String dateStyleType;
 
+    @NotNull(message = "개인 질문이 입력되지 않았습니다.")
+    private String memberAsk;
+
     public Mbti getMbti() {
         return Mbti.from(mbti);
     }
@@ -63,5 +66,9 @@ public class MemberStyleUpdateRequest {
 
     public DateStyleType getDateStyleType() {
         return DateStyleType.from(dateStyleType);
+    }
+
+    public String getMemberAsk() {
+        return memberAsk;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberStyleResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberStyleResponse.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.member.controller.dto.response;
 
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberStyle;
+import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,8 +19,9 @@ public class MemberStyleResponse {
     private final String justFriendType;
     private final String drinkType;
     private final String mbti;
+    private final String memberAsk;
 
-    public static MemberStyleResponse of(Member member, MemberStyle memberStyle) {
+    public static MemberStyleResponse of(Member member, MemberStyle memberStyle, MemberAsk memberAsk) {
         return new MemberStyleResponse(
                 member.getId(),
                 memberStyle.getId(),
@@ -29,7 +31,8 @@ public class MemberStyleResponse {
                 memberStyle.getDateStyleType().getValue(),
                 memberStyle.getJustFriendType().getValue(),
                 memberStyle.getDrinkType().getValue(),
-                memberStyle.getMbti().name()
+                memberStyle.getMbti().name(),
+                memberAsk.getContents()
         );
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberStyleServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberStyleServiceImpl.java
@@ -8,6 +8,8 @@ import com.bookbla.americano.domain.member.repository.MemberStyleRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberStyle;
 import com.bookbla.americano.domain.member.service.MemberStyleService;
+import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
+import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,35 +22,44 @@ public class MemberStyleServiceImpl implements MemberStyleService {
 
     private final MemberRepository memberRepository;
     private final MemberStyleRepository memberStyleRepository;
+    private final MemberAskRepository memberAskRepository;
 
     @Override
     @Transactional(readOnly = true)
     public MemberStyleResponse readMemberStyle(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberStyle memberStyle = memberStyleRepository.getByMemberOrThrow(member);
+        MemberAsk memberAsk = memberAskRepository.getByMemberOrThrow(member);
 
-        return MemberStyleResponse.of(member, memberStyle);
+        return MemberStyleResponse.of(member, memberStyle, memberAsk);
     }
 
     @Override
     public MemberStyleResponse createMemberStyle(Long memberId, MemberStyleCreateRequest memberStyleCreateRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberStyle memberStyle = memberStyleCreateRequest.toMemberStyleWith(member);
+        MemberAsk memberAsk = MemberAsk.builder()
+                .member(member)
+                .contents(memberStyleCreateRequest.getMemberAsk())
+                .build();
 
         MemberStyle savedMemberStyle = memberStyleRepository.save(memberStyle);
+        MemberAsk savedMemberAsk = memberAskRepository.save(memberAsk);
 
-        return MemberStyleResponse.of(member, savedMemberStyle);
+        return MemberStyleResponse.of(member, savedMemberStyle, savedMemberAsk);
     }
 
     @Override
     public void updateMemberStyle(Long memberId, MemberStyleUpdateRequest memberStyleUpdateRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberStyle memberStyle = memberStyleRepository.getByMemberOrThrow(member);
+        MemberAsk memberAsk  = memberAskRepository.getByMemberOrThrow(member);
 
-        update(memberStyle, memberStyleUpdateRequest);
+        memberAsk.updateContent(memberStyleUpdateRequest.getMemberAsk());
+        updateMemberStyle(memberStyle, memberStyleUpdateRequest);
     }
 
-    private void update(MemberStyle memberStyle, MemberStyleUpdateRequest request) {
+    private void updateMemberStyle(MemberStyle memberStyle, MemberStyleUpdateRequest request) {
         memberStyle.updateMbti(request.getMbti())
                 .updateDrinkType(request.getDrinkType())
                 .updateDateCostType(request.getDateCostType())

--- a/src/test/java/com/bookbla/americano/domain/member/service/MemberStyleServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/member/service/MemberStyleServiceTest.java
@@ -26,6 +26,8 @@ import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.MemberStyleRepository;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberStyleResponse;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberStyleUpdateRequest;
+import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
+import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,9 @@ class MemberStyleServiceTest {
     @Autowired
     private MemberStyleRepository memberStyleRepository;
 
+    @Autowired
+    private MemberAskRepository memberAskRepository;
+
     @Test
     void 회원의_스타일을_생성할_수_있다() {
         // given
@@ -54,7 +59,7 @@ class MemberStyleServiceTest {
                 .oauthEmail("bookbla@bookbla.com")
                 .build());
         MemberStyleCreateRequest memberStyleCreateRequest = new MemberStyleCreateRequest(
-                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트"
+                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트", "주로 어디서 책을 읽는 편이세요?"
         );
 
         // when
@@ -71,7 +76,8 @@ class MemberStyleServiceTest {
                 () -> assertThat(memberStyleResponse.getSmokeType()).isEqualTo("비흡연"),
                 () -> assertThat(memberStyleResponse.getContactType()).isEqualTo("느긋이"),
                 () -> assertThat(memberStyleResponse.getJustFriendType()).isEqualTo("허용 X"),
-                () -> assertThat(memberStyleResponse.getDateStyleType()).isEqualTo("집 데이트")
+                () -> assertThat(memberStyleResponse.getDateStyleType()).isEqualTo("집 데이트"),
+                () -> assertThat(memberStyleResponse.getMemberAsk()).isEqualTo("주로 어디서 책을 읽는 편이세요?")
         );
     }
 
@@ -92,6 +98,11 @@ class MemberStyleServiceTest {
                 .mbti(INTP)
                 .dateCostType(DATE_ACCOUNT)
                 .build());
+        memberAskRepository.save(MemberAsk
+                .builder()
+                .member(member)
+                .contents("주로 어디서 책을 읽으세요?")
+                .build());
 
         // when
         MemberStyleResponse memberStyleResponse = memberStyleService.readMemberStyle(
@@ -106,7 +117,8 @@ class MemberStyleServiceTest {
                 () -> assertThat(memberStyleResponse.getDateStyleType()).isEqualTo("집 데이트"),
                 () -> assertThat(memberStyleResponse.getJustFriendType()).isEqualTo("단둘이 술 먹기"),
                 () -> assertThat(memberStyleResponse.getDrinkType()).isEqualTo("안마심"),
-                () -> assertThat(memberStyleResponse.getMbti()).isEqualToIgnoringCase("intp")
+                () -> assertThat(memberStyleResponse.getMbti()).isEqualToIgnoringCase("intp"),
+                () -> assertThat(memberStyleResponse.getMemberAsk()).isEqualTo("주로 어디서 책을 읽으세요?")
         );
     }
 
@@ -155,8 +167,12 @@ class MemberStyleServiceTest {
                 .mbti(INTP)
                 .dateCostType(DATE_ACCOUNT)
                 .build());
+        memberAskRepository.save(MemberAsk.builder()
+                .member(member)
+                .contents("어느 시간대에 책을 읽으시나요?")
+                .build());
         MemberStyleUpdateRequest memberStyleUpdateRequest = new MemberStyleUpdateRequest(
-                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트"
+                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트", "주로 어디서 책을 읽는 편이세요?"
         );
 
         // when
@@ -180,7 +196,7 @@ class MemberStyleServiceTest {
         // given
         Long nonMemberId = -999999L;
         MemberStyleUpdateRequest memberStyleUpdateRequest = new MemberStyleUpdateRequest(
-                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트"
+                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트", "주로 어디서 책을 읽으세요?"
         );
 
         // when, then
@@ -197,7 +213,7 @@ class MemberStyleServiceTest {
                 .oauthEmail("bookbla@bookbla.com")
                 .build());
         MemberStyleUpdateRequest memberStyleUpdateRequest = new MemberStyleUpdateRequest(
-                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트"
+                "infj", "매일", "더치페이", "비흡연", "느긋이", "허용 X", "집 데이트", "주로 어디서 책을 읽으세요?"
         );
 
         // when, then


### PR DESCRIPTION
## 📄 Summary

> 개인 질문 생성/수정시 개인 질문도 함께 보내도록 수정하였습니다

엽서 보내는데 개인 질문이 필요해서, 따른 엔티티로 빼놨었는데
기획 변경에 따라 스타일 생성/수정시 스타일을 함께 보내도록 API 부분만 변경했습니다

## 🙋🏻 More

>