### PR TITLE
feat: 내 서재 관련 기능 구현

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.member.controller;
 
 import com.bookbla.americano.base.jwt.LoginUser;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookCreateRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberBookUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookCreateResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.service.MemberBookService;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,6 +41,15 @@ public class MemberBookController {
     public ResponseEntity<MemberBookReadResponses> readMemberBooks(@LoginUser Long memberId) {
         MemberBookReadResponses memberBookReadResponses = memberBookService.readMemberBooks(memberId);
         return ResponseEntity.ok(memberBookReadResponses);
+    }
+
+    @PutMapping("/{memberBookId}")
+    public ResponseEntity<Void> updateMemberBook(
+            @PathVariable Long memberBookId, @LoginUser Long memberId,
+            @RequestBody @Valid MemberBookUpdateRequest memberBookUpdateRequest
+    ) {
+        memberBookService.updateMemberBook(memberBookUpdateRequest, memberBookId, memberId);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{memberBookId}")

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
@@ -4,6 +4,7 @@ import com.bookbla.americano.base.jwt.LoginUser;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookCreateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookCreateResponse;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.service.MemberBookService;
 import java.net.URI;
@@ -41,6 +42,12 @@ public class MemberBookController {
     public ResponseEntity<MemberBookReadResponses> readMemberBooks(@LoginUser Long memberId) {
         MemberBookReadResponses memberBookReadResponses = memberBookService.readMemberBooks(memberId);
         return ResponseEntity.ok(memberBookReadResponses);
+    }
+
+    @GetMapping("/{memberBookId}")
+    public ResponseEntity<MemberBookReadResponse> readMemberBook(@PathVariable Long memberBookId) {
+        MemberBookReadResponse memberBookReadResponse = memberBookService.readMemberBook(memberBookId);
+        return ResponseEntity.ok(memberBookReadResponse);
     }
 
     @PutMapping("/{memberBookId}")

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberLibraryController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberLibraryController.java
@@ -1,0 +1,22 @@
+package com.bookbla.americano.domain.member.controller;
+
+import com.bookbla.americano.base.jwt.LoginUser;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberLibraryProfileReadResponse;
+import com.bookbla.americano.domain.member.service.MemberLibraryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/library")
+public class MemberLibraryController {
+
+    private final MemberLibraryService memberLibraryService;
+
+    @GetMapping
+    public ResponseEntity<MemberLibraryProfileReadResponse> readMemberProfile(@LoginUser Long memberId) {
+        MemberLibraryProfileReadResponse memberLibraryProfileReadResponse = memberLibraryService.getLibraryProfile(memberId);
+        return ResponseEntity.ok(memberLibraryProfileReadResponse);
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
@@ -44,8 +44,8 @@ public class MemberProfileController {
     @PutMapping
     public ResponseEntity<MemberProfileResponse> updateMemberProfile(
         @RequestBody @Valid MemberProfileUpdateRequest memberProfileUpdateRequest,
-        @LoginUser Long memberId) {
-
+        @LoginUser Long memberId
+    ) {
         MemberProfileResponse memberProfileResponse =
             memberProfileService.updateMemberProfile(memberId, memberProfileUpdateRequest);
 

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberBookUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberBookUpdateRequest.java
@@ -2,12 +2,12 @@ package com.bookbla.americano.domain.member.controller.dto.request;
 
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 public class MemberBookUpdateRequest {
 

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberBookUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberBookUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.bookbla.americano.domain.member.controller.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
+@Getter
+public class MemberBookUpdateRequest {
+
+    @NotNull(message = "감상문이 입력되지 않았습니다")
+    private String contents;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberBookReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberBookReadResponse.java
@@ -1,0 +1,27 @@
+package com.bookbla.americano.domain.member.controller.dto.response;
+
+import com.bookbla.americano.domain.book.repository.entity.Book;
+import com.bookbla.americano.domain.member.repository.entity.MemberBook;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberBookReadResponse {
+
+    private final String title;
+    private final Set<String> authors;
+    private final String imageUrl;
+    private final String review;
+
+    public static MemberBookReadResponse of(MemberBook memberBook) {
+        Book book = memberBook.getBook();
+        return new MemberBookReadResponse(
+                book.getTitle(),
+                book.getAuthors(),
+                book.getImageUrl(),
+                memberBook.getReview()
+        );
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberLibraryProfileReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberLibraryProfileReadResponse.java
@@ -1,0 +1,50 @@
+package com.bookbla.americano.domain.member.controller.dto.response;
+
+import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.member.repository.entity.MemberBook;
+import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberLibraryProfileReadResponse {
+
+    private final Long memberId;
+    private final Long memberProfileId;
+    private final String name;
+    private final int age;
+    private final String gender;
+    private final String school;
+    private final String profileImageUrl;
+    private final List<BookResponse> bookResponses;
+
+    @Getter
+    @AllArgsConstructor
+    public static class BookResponse {
+
+        private final Long memberBookId;
+        private final String bookImageUrl;
+
+    }
+
+    public static MemberLibraryProfileReadResponse of(Member member, MemberProfile memberProfile, List<MemberBook> memberBooks) {
+        List<BookResponse> bookResponses = memberBooks.stream()
+                .map(it -> new BookResponse(it.getId(), it.getBook().getImageUrl()))
+                .collect(Collectors.toList());
+        return new MemberLibraryProfileReadResponse(
+                member.getId(),
+                memberProfile.getId(),
+                memberProfile.showBlindName(),
+                memberProfile.calculateAge(LocalDate.now()),
+                memberProfile.getGender().name(),
+                memberProfile.getSchoolName(),
+                memberProfile.getProfileImageUrl(),
+                bookResponses
+        );
+    }
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
@@ -55,6 +55,11 @@ public class MemberProfile {
 
     private String openKakaoRoomUrl;
 
+    public String showBlindName() {
+        String firstName = name.split("")[0];
+        return firstName + "OO";
+    }
+
     public int calculateAge(LocalDate now) {
         int age = Period.between(birthDate, now).getYears();
 

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.member.repository.entity;
 
 import com.bookbla.americano.domain.member.enums.Gender;
+import java.time.Period;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -53,6 +54,16 @@ public class MemberProfile {
     private String nickname;
 
     private String openKakaoRoomUrl;
+
+    public int calculateAge(LocalDate now) {
+        int age = Period.between(birthDate, now).getYears();
+
+        if (now.isBefore(birthDate.plusYears(age))) {
+            age--;
+        }
+
+        return age;
+    }
 
     public MemberProfile updateName(String name) {
         this.name = name;

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberBookService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberBookService.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.member.service;
 
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookCreateRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberBookUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookCreateResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 
@@ -12,4 +13,5 @@ public interface MemberBookService {
 
     void deleteMemberBook(Long memberId, Long memberBookId);
 
+    void updateMemberBook(MemberBookUpdateRequest memberBookUpdateRequest, Long memberBookId, Long memberId);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberBookService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberBookService.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.member.service;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookCreateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookCreateResponse;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 
 public interface MemberBookService {
@@ -10,6 +11,8 @@ public interface MemberBookService {
     MemberBookCreateResponse addMemberBook(Long memberId, MemberBookCreateRequest memberBookCreateRequest);
 
     MemberBookReadResponses readMemberBooks(Long memberId);
+
+    MemberBookReadResponse readMemberBook(Long memberBookId);
 
     void deleteMemberBook(Long memberId, Long memberBookId);
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberLibraryService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberLibraryService.java
@@ -1,0 +1,9 @@
+package com.bookbla.americano.domain.member.service;
+
+import com.bookbla.americano.domain.member.controller.dto.response.MemberLibraryProfileReadResponse;
+
+public interface MemberLibraryService {
+
+    MemberLibraryProfileReadResponse getLibraryProfile(Long memberId);
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -8,6 +8,7 @@ import com.bookbla.americano.domain.book.repository.BookRepository;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookCreateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookCreateResponse;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.exception.MemberBookExceptionType;
 import com.bookbla.americano.domain.member.exception.MemberProfileExceptionType;
@@ -69,6 +70,13 @@ public class MemberBookServiceImpl implements MemberBookService {
 
         List<MemberBook> memberBooks = memberBookRepository.findByMember(member);
         return MemberBookReadResponses.from(memberBooks);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberBookReadResponse readMemberBook(Long memberBookId) {
+        MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
+        return MemberBookReadResponse.of(memberBook);
     }
 
     @Override

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -6,6 +6,7 @@ import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.book.repository.entity.Book;
 import com.bookbla.americano.domain.book.repository.BookRepository;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookCreateRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberBookUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookCreateResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.exception.MemberBookExceptionType;
@@ -71,6 +72,20 @@ public class MemberBookServiceImpl implements MemberBookService {
     }
 
     @Override
+    public void updateMemberBook(
+            MemberBookUpdateRequest memberBookUpdateRequest,
+            Long memberBookId, Long memberId
+    ) {
+        Member member = memberRepository.getByIdOrThrow(memberId);
+        MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
+
+        memberBook.validateOwner(member);
+
+        memberBook.updateReview(memberBookUpdateRequest.getContents());
+    }
+
+
+    @Override
     public void deleteMemberBook(Long memberId, Long memberBookId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
@@ -79,5 +94,6 @@ public class MemberBookServiceImpl implements MemberBookService {
 
         memberBookRepository.deleteById(memberBookId);
     }
+
 
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -1,0 +1,33 @@
+package com.bookbla.americano.domain.member.service.impl;
+
+import com.bookbla.americano.domain.member.controller.dto.response.MemberLibraryProfileReadResponse;
+import com.bookbla.americano.domain.member.repository.MemberBookRepository;
+import com.bookbla.americano.domain.member.repository.MemberProfileRepository;
+import com.bookbla.americano.domain.member.repository.MemberRepository;
+import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.member.repository.entity.MemberBook;
+import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
+import com.bookbla.americano.domain.member.service.MemberLibraryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberLibraryServiceImpl implements MemberLibraryService {
+
+    private final MemberRepository memberRepository;
+    private final MemberProfileRepository memberProfileRepository;
+    private final MemberBookRepository memberBookRepository;
+
+    @Override
+    public MemberLibraryProfileReadResponse getLibraryProfile(Long memberId) {
+        Member member = memberRepository.getByIdOrThrow(memberId);
+        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(member);
+        List<MemberBook> memberBooks = memberBookRepository.findByMember(member);
+
+        return MemberLibraryProfileReadResponse.of(member, memberProfile, memberBooks);
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
@@ -44,4 +44,24 @@ public class QuizQuestion extends BaseInsertEntity {
     @Enumerated(EnumType.STRING)
     private AnswerChoice answerChoice = AnswerChoice.FIRST;
 
+    public QuizQuestion updateContents(String contents) {
+        this.contents = contents;
+        return this;
+    }
+
+    public QuizQuestion updateCorrectAnswer(String answer) {
+        this.firstChoice = answer;
+        return this;
+    }
+
+    public QuizQuestion updateFirstWrongAnswer(String firstWrongAnswer) {
+        this.secondChoice = firstWrongAnswer;
+        return this;
+    }
+
+    public QuizQuestion updateSecondWrongAnswer(String secondWrongAnswer) {
+        this.thirdChoice = secondWrongAnswer;
+        return this;
+    }
+
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/QuizController.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.quiz.controller;
 
 import com.bookbla.americano.base.jwt.LoginUser;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
+import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
 import com.bookbla.americano.domain.quiz.service.QuizQuestionService;
 import java.net.URI;
 import javax.validation.Valid;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +31,15 @@ public class QuizController {
         return ResponseEntity
                 .created(URI.create("/quizzes/" + quizQuestionId.toString()))
                 .build();
+    }
+
+    @PutMapping("/{memberBookId}")
+    public ResponseEntity<Void> createQuizQuestion(
+            @LoginUser Long memberId, @PathVariable Long memberBookId,
+            @RequestBody @Valid QuizQuestionUpdateRequest quizQuestionUpdateRequest
+    ) {
+        quizQuestionService.updateQuizQuestion(memberId, memberBookId, quizQuestionUpdateRequest);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/request/QuizQuestionUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/request/QuizQuestionUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.bookbla.americano.domain.quiz.controller.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QuizQuestionUpdateRequest {
+
+    @NotBlank(message = "퀴즈가 입력되지 않았습니다.")
+    private String quiz;
+
+    @NotBlank(message = "퀴즈 정답이 입력되지 않았습니다.")
+    private String quizAnswer;
+
+    @NotBlank(message = "퀴즈 답안이 입력되지 않았습니다.")
+    private String firstWrongChoice;
+
+    @NotBlank(message = "퀴즈 답안이 입력되지 않았습니다.")
+    private String secondWrongChoice;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/request/QuizQuestionUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/request/QuizQuestionUpdateRequest.java
@@ -2,12 +2,12 @@ package com.bookbla.americano.domain.quiz.controller.dto.request;
 
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuizQuestionUpdateRequest {
 

--- a/src/main/java/com/bookbla/americano/domain/quiz/exception/QuizQuestionExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/exception/QuizQuestionExceptionType.java
@@ -1,0 +1,19 @@
+package com.bookbla.americano.domain.quiz.exception;
+
+import com.bookbla.americano.base.exception.ExceptionType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuizQuestionExceptionType implements ExceptionType {
+
+    MEMBER_QUIZ_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QuizQuestion-001", "해당 회원의 독서 퀴즈가 등록되지 않았습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizQuestionRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizQuestionRepository.java
@@ -1,8 +1,11 @@
 package com.bookbla.americano.domain.quiz.repository;
 
+import com.bookbla.americano.domain.member.repository.entity.MemberBook;
 import com.bookbla.americano.domain.quiz.QuizQuestion;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long> {
 
+    Optional<QuizQuestion> findByMemberBook(MemberBook memberBook);
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/QuizQuestionService.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/QuizQuestionService.java
@@ -1,9 +1,12 @@
 package com.bookbla.americano.domain.quiz.service;
 
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
+import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
 
 public interface QuizQuestionService {
 
     Long createQuizQuestion(Long memberId, Long memberBookId, QuizQuestionCreateRequest quizQuestionCreateRequest);
+
+    void updateQuizQuestion(Long memberId, Long memberBookId, QuizQuestionUpdateRequest quizQuestionUpdateRequest);
 
 }

--- a/src/test/java/com/bookbla/americano/domain/member/repository/entity/MemberProfileTest.java
+++ b/src/test/java/com/bookbla/americano/domain/member/repository/entity/MemberProfileTest.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -41,6 +43,21 @@ class MemberProfileTest {
 
         // then
         assertThat(age).isEqualTo(18);
+    }
+
+    @ValueSource(strings = {"김", "김수", "김수한", "김수한무", "김수한무거", "김수한무거북", "김수한무거북이"})
+    @ParameterizedTest(name = "이름은 첫 글자와 익명 두 글자를 합쳐_보여준다")
+    void 이름은_첫_글자와_익명_두_글자를_합쳐_보여준다(String value) {
+        // given
+        MemberProfile memberProfile = MemberProfile.builder()
+                .name(value)
+                .build();
+
+        // when
+        String actual = memberProfile.showBlindName();
+
+        // then
+        assertThat(actual).isEqualTo("김OO");
     }
 
 }

--- a/src/test/java/com/bookbla/americano/domain/member/repository/entity/MemberProfileTest.java
+++ b/src/test/java/com/bookbla/americano/domain/member/repository/entity/MemberProfileTest.java
@@ -1,0 +1,46 @@
+package com.bookbla.americano.domain.member.repository.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MemberProfileTest {
+
+    @Test
+    void 생일이_지난_만_나이를_계산할_수_있다() {
+        // given
+        LocalDate baseDate = LocalDate.of(2024, 3, 1);
+        LocalDate birthDate = LocalDate.of(2005, 3, 1);
+        MemberProfile memberProfile = MemberProfile.builder()
+                .birthDate(birthDate)
+                .build();
+
+        // when
+        int age = memberProfile.calculateAge(baseDate);
+
+        // then
+        assertThat(age).isEqualTo(19);
+    }
+
+    @Test
+    void 생일이_지나지_않은_만_나이를_계산할_수_있다() {
+        // given
+        LocalDate baseDate = LocalDate.of(2024, 3, 1);
+        LocalDate birthDate = LocalDate.of(2005, 3, 2);
+        MemberProfile memberProfile = MemberProfile.builder()
+                .birthDate(birthDate)
+                .build();
+
+        // when
+        int age = memberProfile.calculateAge(baseDate);
+
+        // then
+        assertThat(age).isEqualTo(18);
+    }
+
+}


### PR DESCRIPTION
## 📄 Summary

> 내 서재 관련 API들을 추가하였습니다

- 프로필 조회 API
- 책 상세 정보 API
- 독서퀴즈 업데이트 API

요렇게 세 개입니다

추가로 프론트 입장에선 API 디자인이 어색해진 부분들이 많은데, 한번 얘기 나눠보면 좋을 것 같습니다~

## 🙋🏻 More

> 내 서재와 상대방 서재 겹치는 부분이 있어서, 머지 빠르게 하고 태완님이 이어서 작업하실 것 같아요~