### PR TITLE
Feat/quiz - 퀴즈 조회 기능 제작

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBook.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBook.java
@@ -51,6 +51,10 @@ public class MemberBook extends BaseInsertEntity {
         }
     }
 
+    public boolean isOwner(Member other) {
+        return this.member.equals(other);
+    }
+
     public void updateReview(String review) {
         if (review.length() > MAX_REVIEW_LENGTH) {
             throw new BaseException(MemberBookExceptionType.REVIEW_LENGTH_NOT_VALID);

--- a/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
@@ -10,14 +10,17 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -64,4 +67,22 @@ public class QuizQuestion extends BaseInsertEntity {
         return this;
     }
 
+    public QuizQuestion shuffleChoices(QuizQuestion quizQuestion) {
+        // 선택지를 리스트로 변환
+        List<String> choices = new ArrayList<>(Arrays.asList(
+                quizQuestion.getFirstChoice(),
+                quizQuestion.getSecondChoice(),
+                quizQuestion.getThirdChoice()
+        ));
+
+        // 선택지 리스트를 랜덤하게 섞음
+        Collections.shuffle(choices);
+
+        // 랜덤하게 섞인 선택지를 다시 QuizQuestion 객체에 설정
+        quizQuestion.setFirstChoice(choices.get(0));
+        quizQuestion.setSecondChoice(choices.get(1));
+        quizQuestion.setThirdChoice(choices.get(2));
+
+        return quizQuestion;
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
@@ -13,11 +13,6 @@ import javax.persistence.OneToOne;
 
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 @Entity
 @Getter
 @Builder
@@ -64,24 +59,5 @@ public class QuizQuestion extends BaseInsertEntity {
     public QuizQuestion updateSecondWrongAnswer(String secondWrongAnswer) {
         this.thirdChoice = secondWrongAnswer;
         return this;
-    }
-
-    public QuizQuestion shuffleChoices(QuizQuestion quizQuestion) {
-        // 선택지를 리스트로 변환
-        List<String> choices = new ArrayList<>(Arrays.asList(
-                quizQuestion.getFirstChoice(),
-                quizQuestion.getSecondChoice(),
-                quizQuestion.getThirdChoice()
-        ));
-
-        // 선택지 리스트를 랜덤하게 섞음
-        Collections.shuffle(choices);
-
-        // 랜덤하게 섞인 선택지를 다시 QuizQuestion 객체에 설정
-        quizQuestion.firstChoice = choices.get(0);
-        quizQuestion.secondChoice = choices.get(1);
-        quizQuestion.thirdChoice = choices.get(2);
-
-        return quizQuestion;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/QuizQuestion.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -79,9 +78,9 @@ public class QuizQuestion extends BaseInsertEntity {
         Collections.shuffle(choices);
 
         // 랜덤하게 섞인 선택지를 다시 QuizQuestion 객체에 설정
-        quizQuestion.setFirstChoice(choices.get(0));
-        quizQuestion.setSecondChoice(choices.get(1));
-        quizQuestion.setThirdChoice(choices.get(2));
+        quizQuestion.firstChoice = choices.get(0);
+        quizQuestion.secondChoice = choices.get(1);
+        quizQuestion.thirdChoice = choices.get(2);
 
         return quizQuestion;
     }

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/QuizController.java
@@ -3,17 +3,13 @@ package com.bookbla.americano.domain.quiz.controller;
 import com.bookbla.americano.base.jwt.LoginUser;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
+import com.bookbla.americano.domain.quiz.controller.dto.response.QuizQuestionReadResponse;
 import com.bookbla.americano.domain.quiz.service.QuizQuestionService;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +27,14 @@ public class QuizController {
         return ResponseEntity
                 .created(URI.create("/quizzes/" + quizQuestionId.toString()))
                 .build();
+    }
+
+    @GetMapping("/{memberBookId}")
+    public ResponseEntity<QuizQuestionReadResponse> createQuizQuestion(
+            @LoginUser Long memberId, @PathVariable Long memberBookId
+    ) {
+        QuizQuestionReadResponse quizQuestionReadResponse = quizQuestionService.getQuizQuestion(memberId, memberBookId);
+        return ResponseEntity.ok(quizQuestionReadResponse);
     }
 
     @PutMapping("/{memberBookId}")

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/response/QuizQuestionReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/response/QuizQuestionReadResponse.java
@@ -5,6 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -24,5 +28,23 @@ public class QuizQuestionReadResponse {
                 .secondChoice(quizQuestion.getSecondChoice())
                 .thirdChoice(quizQuestion.getThirdChoice())
                 .build();
+        }
+
+        public static QuizQuestionReadResponse fromShuffledChoices(QuizQuestion quizQuestion) {
+                List<String> choices = Arrays.asList(
+                        quizQuestion.getFirstChoice(),
+                        quizQuestion.getSecondChoice(),
+                        quizQuestion.getThirdChoice()
+                );
+
+                Collections.shuffle(choices);
+
+                return QuizQuestionReadResponse.builder()
+                        .id(quizQuestion.getId())
+                        .quiz(quizQuestion.getContents())
+                        .firstChoice(choices.get(0))
+                        .secondChoice(choices.get(1))
+                        .thirdChoice(choices.get(2))
+                        .build();
         }
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/response/QuizQuestionReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/response/QuizQuestionReadResponse.java
@@ -1,0 +1,28 @@
+package com.bookbla.americano.domain.quiz.controller.dto.response;
+
+import com.bookbla.americano.domain.quiz.QuizQuestion;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class QuizQuestionReadResponse {
+
+        private Long id;
+        private String quiz;
+        private String firstChoice;
+        private String secondChoice;
+        private String thirdChoice;
+
+        public static QuizQuestionReadResponse from(QuizQuestion quizQuestion) {
+            return QuizQuestionReadResponse.builder()
+                .id(quizQuestion.getId())
+                .quiz(quizQuestion.getContents())
+                .firstChoice(quizQuestion.getFirstChoice())
+                .secondChoice(quizQuestion.getSecondChoice())
+                .thirdChoice(quizQuestion.getThirdChoice())
+                .build();
+        }
+}

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/QuizQuestionService.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/QuizQuestionService.java
@@ -1,7 +1,9 @@
 package com.bookbla.americano.domain.quiz.service;
 
+import com.bookbla.americano.domain.quiz.QuizQuestion;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
+import com.bookbla.americano.domain.quiz.controller.dto.response.QuizQuestionReadResponse;
 
 public interface QuizQuestionService {
 
@@ -9,4 +11,5 @@ public interface QuizQuestionService {
 
     void updateQuizQuestion(Long memberId, Long memberBookId, QuizQuestionUpdateRequest quizQuestionUpdateRequest);
 
+    QuizQuestionReadResponse getQuizQuestion(Long memberId, Long memberBookId);
 }

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
@@ -48,12 +48,12 @@ public class QuizQuestionServiceImpl implements QuizQuestionService {
         QuizQuestion quizQuestion = quizQuestionRepository.findByMemberBook(memberBook)
                 .orElseThrow(() -> new BaseException(QuizQuestionExceptionType.MEMBER_QUIZ_QUESTION_NOT_FOUND));
 
-        // 자신의 책이면 그대로 반환, 나머지 책이면 1, 2, 3 순서를 랜덤으로 섞어서 반환
         if (!memberBook.isOwner(member)) {
-            return QuizQuestionReadResponse.from(quizQuestion.shuffleChoices(quizQuestion));
+            return QuizQuestionReadResponse.fromShuffledChoices(quizQuestion);
         }
         return QuizQuestionReadResponse.from(quizQuestion);
     }
+
 
     @Override
     public void updateQuizQuestion(

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
@@ -8,6 +8,7 @@ import com.bookbla.americano.domain.member.repository.entity.MemberBook;
 import com.bookbla.americano.domain.quiz.QuizQuestion;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
+import com.bookbla.americano.domain.quiz.controller.dto.response.QuizQuestionReadResponse;
 import com.bookbla.americano.domain.quiz.exception.QuizQuestionExceptionType;
 import com.bookbla.americano.domain.quiz.repository.QuizQuestionRepository;
 import com.bookbla.americano.domain.quiz.service.QuizQuestionService;
@@ -36,6 +37,21 @@ public class QuizQuestionServiceImpl implements QuizQuestionService {
 
         QuizQuestion quizQuestion = quizQuestionCreateRequest.toQuizQuestionWith(memberBook);
         return quizQuestionRepository.save(quizQuestion).getId();
+    }
+
+    @Override
+    public QuizQuestionReadResponse getQuizQuestion(Long memberId, Long memberBookId) {
+        Member member = memberRepository.getByIdOrThrow(memberId);
+        MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
+
+        QuizQuestion quizQuestion = quizQuestionRepository.findByMemberBook(memberBook)
+                .orElseThrow(() -> new BaseException(QuizQuestionExceptionType.MEMBER_QUIZ_QUESTION_NOT_FOUND));
+
+        // 자신의 책이면 그대로 반환, 나머지 책이면 1, 2, 3 순서를 랜덤으로 섞어서 반환
+        if (!memberBook.isOwner(member)) {
+            return QuizQuestionReadResponse.from(quizQuestion.shuffleChoices(quizQuestion));
+        }
+        return QuizQuestionReadResponse.from(quizQuestion);
     }
 
     @Override

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
@@ -40,6 +40,7 @@ public class QuizQuestionServiceImpl implements QuizQuestionService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public QuizQuestionReadResponse getQuizQuestion(Long memberId, Long memberBookId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);


### PR DESCRIPTION
## 📄 Summary

> 퀴즈 내용을 조회합니다.

- 자신의 퀴즈면 순서를 고정시켜서 반환합니다. 
- 자신의 퀴즈가 아니면 순서를 랜덤으로 섞어서 반환합니다.

## 🙋🏻 More

> 궁금한 점

- isOwner함수를 추가하여 본인인지 아닌지 판단하는 기능을 추가했지만. validateOwner함수를 수정하면, 함수의 중복을 제거할 수 있을 것 같은데 어떻게 생각하시나요? (validateOwner을 쓰고있는 부분이 많은 것 같아서 일단 건드리지는 못했습니다.)

```
public boolean isOwner(Member other) {
        return this.member.equals(other);
}
```

- 무조건 첫 번째 답을 Answer에 추가하면, 다음 기능은 어떤 용도로 사용되는지 궁금합니다!. (답을 수정해도 FIRST는 바뀌지 않고 first_choice만 바뀌는 것 같습니다.

```
public enum AnswerChoice {
    FIRST,
    SECOND,
    THIRD,
    ;
}
```