### PR TITLE
refactor: 영속성 계층 내 불필요한 엔티티 의존 제거

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberAuthRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberAuthRepository.java
@@ -1,18 +1,11 @@
 package com.bookbla.americano.domain.member.repository;
 
-import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.member.exception.MemberAuthExceptionType;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberAuth;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberAuthRepository extends JpaRepository<MemberAuth, Long> {
-
-    default MemberAuth getByMemberOrThrow(Member member) {
-        return findByMember(member)
-            .orElseThrow(() -> new BaseException(MemberAuthExceptionType.MEMBER_AUTH_NOT_FOUND));
-    }
 
     Optional<MemberAuth> findByMember(Member member);
 

--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberPolicyRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberPolicyRepository.java
@@ -2,7 +2,7 @@ package com.bookbla.americano.domain.member.repository;
 
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPolicy;
-import com.bookbla.americano.domain.member.repository.entity.Policy;
+import com.bookbla.americano.domain.policy.Policy;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberProfileRepository.java
@@ -1,19 +1,12 @@
 package com.bookbla.americano.domain.member.repository;
 
 import com.bookbla.americano.domain.member.repository.custom.MemberProfileRepositoryCustom;
-import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberProfileRepository  extends JpaRepository<MemberProfile, Long>, MemberProfileRepositoryCustom {
-
-    default MemberProfile getByMemberOrThrow(Member member) {
-        return findByMember(member)
-            .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
-    }
 
     Optional<MemberProfile> findByMember(Member member);
 

--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberStyleRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberStyleRepository.java
@@ -1,18 +1,12 @@
 package com.bookbla.americano.domain.member.repository;
 
-import com.bookbla.americano.base.exception.BaseException;
+import java.util.Optional;
+
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberStyle;
-import com.bookbla.americano.domain.member.exception.MemberExceptionType;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberStyleRepository extends JpaRepository<MemberStyle, Long> {
-
-    default MemberStyle getByMemberOrThrow(Member member) {
-        return findByMember(member)
-                .orElseThrow(() -> new BaseException(MemberExceptionType.STYLE_NOT_REGISTERED));
-    }
 
     Optional<MemberStyle> findByMember(Member member);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/PostcardRepository.java
@@ -4,8 +4,6 @@ import com.bookbla.americano.domain.postcard.Postcard;
 import com.bookbla.americano.domain.postcard.PostcardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface PostcardRepository extends JpaRepository<Postcard, Long> {
-    Boolean existsBySendMemberIdAndReciveMemberIdAndPostcardStatus(Long sendMemberId, Long reciveMemberId, PostcardStatus status);
+    boolean existsBySendMemberIdAndReciveMemberIdAndPostcardStatus(Long sendMemberId, Long reciveMemberId, PostcardStatus status);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/PostcardRepository.java
@@ -5,5 +5,5 @@ import com.bookbla.americano.domain.postcard.PostcardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostcardRepository extends JpaRepository<Postcard, Long> {
-    boolean existsBySendMemberIdAndReciveMemberIdAndPostcardStatus(Long sendMemberId, Long reciveMemberId, PostcardStatus status);
+    boolean existsBySendMemberIdAndReceiveMemberIdAndPostcardStatus(Long sendMemberId, Long receiveMemberId, PostcardStatus status);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPolicy.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPolicy.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.member.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
+import com.bookbla.americano.domain.policy.Policy;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;

--- a/src/main/java/com/bookbla/americano/domain/member/service/dto/MemberPolicyDto.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/dto/MemberPolicyDto.java
@@ -2,7 +2,7 @@ package com.bookbla.americano.domain.member.service.dto;
 
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPolicy;
-import com.bookbla.americano.domain.member.repository.entity.Policy;
+import com.bookbla.americano.domain.policy.Policy;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberAuthServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberAuthServiceImpl.java
@@ -8,6 +8,7 @@ import com.bookbla.americano.domain.member.controller.dto.request.MemberAuthUpda
 import com.bookbla.americano.domain.member.controller.dto.response.MailVerifyResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberAuthResponse;
 import com.bookbla.americano.domain.member.exception.MailExceptionType;
+import com.bookbla.americano.domain.member.exception.MemberAuthExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberAuthRepository;
 import com.bookbla.americano.domain.member.repository.MemberPostcardRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
@@ -61,7 +62,8 @@ public class MemberAuthServiceImpl implements MemberAuthService {
     @Transactional
     public MailVerifyResponse verifyEmail(Long memberId, MailVerifyRequest mailVerifyRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberAuth memberAuth = memberAuthRepository.getByMemberOrThrow(member);
+        MemberAuth memberAuth = memberAuthRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAuthExceptionType.MEMBER_AUTH_NOT_FOUND));
         LocalDateTime nowTime = LocalDateTime.now();
 
         String verifyCode = memberAuth.getEmailVerifyCode();
@@ -93,7 +95,8 @@ public class MemberAuthServiceImpl implements MemberAuthService {
         Member member = memberRepository.getByIdOrThrow(memberId);
         String schoolEmail = mailResendRequest.getSchoolEmail();
 
-        MemberAuth memberAuth = memberAuthRepository.getByMemberOrThrow(member);
+        MemberAuth memberAuth = memberAuthRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAuthExceptionType.MEMBER_AUTH_NOT_FOUND));
 
         String enrolledSchoolEmail = memberAuth.getSchoolEmail();
 
@@ -115,7 +118,8 @@ public class MemberAuthServiceImpl implements MemberAuthService {
     @Transactional
     public MemberAuthResponse readMemberAuth(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberAuth memberAuth = memberAuthRepository.getByMemberOrThrow(member);
+        MemberAuth memberAuth = memberAuthRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAuthExceptionType.MEMBER_AUTH_NOT_FOUND));
 
         return MemberAuthResponse.from(member, memberAuth);
     }
@@ -126,7 +130,8 @@ public class MemberAuthServiceImpl implements MemberAuthService {
         MemberAuthUpdateRequest memberAuthUpdateRequest) {
 
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberAuth memberAuth = memberAuthRepository.getByMemberOrThrow(member);
+        MemberAuth memberAuth = memberAuthRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAuthExceptionType.MEMBER_AUTH_NOT_FOUND));
 
         update(memberAuth, memberAuthUpdateRequest);
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -11,7 +11,8 @@ import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
 import com.bookbla.americano.domain.member.service.MemberLibraryService;
 import java.util.List;
 
-import com.bookbla.americano.domain.postcard.PostcardStatus;
+import com.bookbla.americano.domain.postcard.repository.entity.PostcardStatus;
+import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -47,9 +47,9 @@ public class MemberLibraryServiceImpl implements MemberLibraryService {
 
         boolean isMatched = false;
 
-        if (postcardRepository.existsBySendMemberIdAndReciveMemberIdAndPostcardStatus(memberId, targetMemberId, PostcardStatus.ACCEPT)) {
+        if (postcardRepository.existsBySendMemberIdAndReceiveMemberIdAndPostcardStatus(memberId, targetMemberId, PostcardStatus.ACCEPT)) {
             isMatched = true;
-        } else if (postcardRepository.existsBySendMemberIdAndReciveMemberIdAndPostcardStatus(targetMemberId, memberId, PostcardStatus.ACCEPT)) {
+        } else if (postcardRepository.existsBySendMemberIdAndReceiveMemberIdAndPostcardStatus(targetMemberId, memberId, PostcardStatus.ACCEPT)) {
             isMatched = true;
         }
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -11,7 +11,7 @@ import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
 import com.bookbla.americano.domain.member.service.MemberLibraryService;
 import java.util.List;
 
-import com.bookbla.americano.domain.postcard.repository.entity.PostcardStatus;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -1,7 +1,9 @@
 package com.bookbla.americano.domain.member.service.impl;
 
+import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberLibraryProfileReadResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberTargetLibraryProfileReadResponse;
+import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.*;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
@@ -28,7 +30,8 @@ public class MemberLibraryServiceImpl implements MemberLibraryService {
     @Transactional(readOnly = true)
     public MemberLibraryProfileReadResponse getLibraryProfile(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(member);
+        MemberProfile memberProfile = memberProfileRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
         List<MemberBook> memberBooks = memberBookRepository.findByMember(member);
 
         return MemberLibraryProfileReadResponse.of(member, memberProfile, memberBooks);
@@ -38,7 +41,8 @@ public class MemberLibraryServiceImpl implements MemberLibraryService {
     @Transactional(readOnly = true)
     public MemberTargetLibraryProfileReadResponse getTargetLibraryProfile(Long memberId, Long targetMemberId) {
         Member targetMember = memberRepository.getByIdOrThrow(targetMemberId);
-        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(targetMember);
+        MemberProfile memberProfile = memberProfileRepository.findByMember(targetMember)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
         List<MemberBook> memberBooks = memberBookRepository.findByMember(targetMember);
 
         boolean isMatched = false;

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberPolicyServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberPolicyServiceImpl.java
@@ -6,16 +6,17 @@ import com.bookbla.americano.domain.member.controller.dto.response.MemberPolicyR
 import com.bookbla.americano.domain.member.exception.PolicyExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberPolicyRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
-import com.bookbla.americano.domain.member.repository.PolicyRepository;
+import com.bookbla.americano.domain.policy.repository.PolicyRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPolicy;
-import com.bookbla.americano.domain.member.repository.entity.Policy;
+import com.bookbla.americano.domain.policy.Policy;
 import com.bookbla.americano.domain.member.service.MemberPolicyService;
 import com.bookbla.americano.domain.member.service.dto.MemberPolicyDto;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +37,6 @@ public class MemberPolicyServiceImpl implements MemberPolicyService {
         List<Policy> policies = policyRepository.findAllSortedById();
         List<Boolean> agreedStatuses = memberPolicyDto.getAgreedStatuses();
 
-
         List<MemberPolicy> memberPolicies = new ArrayList<>();
         for (int i = 0; i < policies.size(); i++) {
             MemberPolicy memberPolicy = memberPolicyDto.toEntity(member, policies.get(i), agreedStatuses.get(i));
@@ -52,7 +52,7 @@ public class MemberPolicyServiceImpl implements MemberPolicyService {
         Member member = memberRepository.getByIdOrThrow(memberId);
 
         List<MemberPolicy> memberPolicies = memberPolicyRepository.findAllByMember(member);
-        if(memberPolicies.isEmpty()) {
+        if (memberPolicies.isEmpty()) {
             throw new BaseException(PolicyExceptionType.MEMBER_NOT_REGISTERED);
         }
 
@@ -62,24 +62,23 @@ public class MemberPolicyServiceImpl implements MemberPolicyService {
 
     @Override
     @Transactional
-    public MemberPolicyResponse updateMemberPolicies(Long memberId,
-        MemberPolicyUpdateRequest memberPolicyUpdateRequest) {
-
+    public MemberPolicyResponse updateMemberPolicies(
+            Long memberId, MemberPolicyUpdateRequest memberPolicyUpdateRequest
+    ) {
         Member member = memberRepository.getByIdOrThrow(memberId);
 
         List<Policy> policies = policyRepository.findAllSortedById();
         List<Boolean> agreedStatuses = memberPolicyUpdateRequest.getUpdateStatuses().toList();
 
         for (int i = 0; i < policies.size(); i++) {
-            MemberPolicy memberPolicy = memberPolicyRepository.findByMemberAndPolicy(member,
-                policies.get(i)).orElseThrow(
-                () -> new BaseException(PolicyExceptionType.EACH_POLICY_NOT_REGISTERED));
+            MemberPolicy memberPolicy = memberPolicyRepository.findByMemberAndPolicy(member, policies.get(i))
+                    .orElseThrow(() -> new BaseException(PolicyExceptionType.EACH_POLICY_NOT_REGISTERED));
 
             memberPolicy.updateAgreedStatus(agreedStatuses.get(i));
         }
 
         List<MemberPolicy> memberPolicies = memberPolicyRepository.findAllByMember(member);
-        if(memberPolicies.isEmpty()) {
+        if (memberPolicies.isEmpty()) {
             throw new BaseException(PolicyExceptionType.MEMBER_NOT_REGISTERED);
         }
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberProfileServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberProfileServiceImpl.java
@@ -2,7 +2,6 @@ package com.bookbla.americano.domain.member.service.impl;
 
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookProfileRequestDto;
-import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileStatusUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponseDto;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
@@ -53,7 +52,8 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     @Transactional(readOnly = true)
     public MemberProfileResponse readMemberProfile(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(member);
+        MemberProfile memberProfile = memberProfileRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
 
         return MemberProfileResponse.from(member, memberProfile);
     }
@@ -64,7 +64,8 @@ public class MemberProfileServiceImpl implements MemberProfileService {
         MemberProfileUpdateRequest memberProfileUpdateRequest) {
 
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(member);
+        MemberProfile memberProfile = memberProfileRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
 
         updateEntity(memberProfile, memberProfileUpdateRequest);
 
@@ -75,7 +76,8 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     @Transactional(readOnly = true)
     public MemberProfileStatusResponse readMemberProfileStatus(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(member);
+        MemberProfile memberProfile = memberProfileRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
 
         return MemberProfileStatusResponse.from(memberProfile);
     }
@@ -85,7 +87,8 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     public MemberProfileStatusResponse updateMemberProfileStatus(Long memberId,
         MemberProfileStatusDto memberProfileStatusDto) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberProfile memberProfile = memberProfileRepository.getByMemberOrThrow(member);
+        MemberProfile memberProfile = memberProfileRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.PROFILE_NOT_REGISTERED));
 
         updateStatusEntity(memberProfile, memberProfileStatusDto);
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberStyleServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberStyleServiceImpl.java
@@ -1,13 +1,16 @@
 package com.bookbla.americano.domain.member.service.impl;
 
+import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberStyleCreateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberStyleUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberStyleResponse;
+import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.MemberStyleRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberStyle;
 import com.bookbla.americano.domain.member.service.MemberStyleService;
+import com.bookbla.americano.domain.memberask.exception.MemberAskExceptionType;
 import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +31,10 @@ public class MemberStyleServiceImpl implements MemberStyleService {
     @Transactional(readOnly = true)
     public MemberStyleResponse readMemberStyle(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberStyle memberStyle = memberStyleRepository.getByMemberOrThrow(member);
-        MemberAsk memberAsk = memberAskRepository.getByMemberOrThrow(member);
+        MemberStyle memberStyle = memberStyleRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.STYLE_NOT_REGISTERED));
+        MemberAsk memberAsk  = memberAskRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
 
         return MemberStyleResponse.of(member, memberStyle, memberAsk);
     }
@@ -52,8 +57,10 @@ public class MemberStyleServiceImpl implements MemberStyleService {
     @Override
     public void updateMemberStyle(Long memberId, MemberStyleUpdateRequest memberStyleUpdateRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberStyle memberStyle = memberStyleRepository.getByMemberOrThrow(member);
-        MemberAsk memberAsk  = memberAskRepository.getByMemberOrThrow(member);
+        MemberStyle memberStyle = memberStyleRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.STYLE_NOT_REGISTERED));
+        MemberAsk memberAsk  = memberAskRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
 
         memberAsk.updateContent(memberStyleUpdateRequest.getMemberAsk());
         updateMemberStyle(memberStyle, memberStyleUpdateRequest);

--- a/src/main/java/com/bookbla/americano/domain/memberask/repository/MemberAskRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/repository/MemberAskRepository.java
@@ -1,18 +1,12 @@
 package com.bookbla.americano.domain.memberask.repository;
 
-import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.member.repository.entity.Member;
-import com.bookbla.americano.domain.memberask.exception.MemberAskExceptionType;
-import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import java.util.Optional;
+
+import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberAskRepository extends JpaRepository<MemberAsk, Long> {
-
-    default MemberAsk getByMemberOrThrow(Member member) {
-        return findByMember(member)
-                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
-    }
 
     Optional<MemberAsk> findByMember(Member member);
 }

--- a/src/main/java/com/bookbla/americano/domain/memberask/service/MemberAskService.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/service/MemberAskService.java
@@ -1,10 +1,12 @@
 package com.bookbla.americano.domain.memberask.service;
 
+import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.memberask.controller.dto.request.MemberAskCreateRequest;
 import com.bookbla.americano.domain.memberask.controller.dto.request.MemberAskUpdateRequest;
 import com.bookbla.americano.domain.memberask.controller.dto.response.MemberAskResponse;
+import com.bookbla.americano.domain.memberask.exception.MemberAskExceptionType;
 import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import lombok.RequiredArgsConstructor;
@@ -31,14 +33,16 @@ public class MemberAskService {
     @Transactional(readOnly = true)
     public MemberAskResponse readMemberAsk(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberAsk memberAsk = memberAskRepository.getByMemberOrThrow(member);
+        MemberAsk memberAsk  = memberAskRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
 
         return MemberAskResponse.from(memberAsk);
     }
 
     public void updateMemberAsk(Long memberId, MemberAskUpdateRequest memberAskUpdateRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        MemberAsk memberAsk = memberAskRepository.getByMemberOrThrow(member);
+        MemberAsk memberAsk  = memberAskRepository.findByMember(member)
+                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
 
         memberAsk.updateContent(memberAskUpdateRequest.getContents());
     }

--- a/src/main/java/com/bookbla/americano/domain/policy/Policy.java
+++ b/src/main/java/com/bookbla/americano/domain/policy/Policy.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.member.repository.entity;
+package com.bookbla.americano.domain.policy;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import javax.persistence.Entity;

--- a/src/main/java/com/bookbla/americano/domain/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/policy/repository/PolicyRepository.java
@@ -1,6 +1,6 @@
-package com.bookbla.americano.domain.member.repository;
+package com.bookbla.americano.domain.policy.repository;
 
-import com.bookbla.americano.domain.member.repository.entity.Policy;
+import com.bookbla.americano.domain.policy.Policy;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/bookbla/americano/domain/postcard/Postcard.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/Postcard.java
@@ -37,8 +37,8 @@ public class Postcard extends BaseInsertEntity {
     private Member sendMember;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recive_member_id")
-    private Member reciveMember;
+    @JoinColumn(name = "receive_member_id")
+    private Member receiveMember;
 
     @OneToOne
     @JoinColumn(name = "member_reply_id")

--- a/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardStatus.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.postcard.repository.entity;
+package com.bookbla.americano.domain.postcard.enums;
 
 public enum PostcardStatus {
     PENDING, ACCEPT, REFUSED, EXPIRED, ALL_WRONG

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
@@ -1,7 +1,7 @@
-package com.bookbla.americano.domain.member.repository;
+package com.bookbla.americano.domain.postcard.repository;
 
-import com.bookbla.americano.domain.postcard.Postcard;
-import com.bookbla.americano.domain.postcard.PostcardStatus;
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import com.bookbla.americano.domain.postcard.repository.entity.PostcardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostcardRepository extends JpaRepository<Postcard, Long> {

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
@@ -1,7 +1,7 @@
 package com.bookbla.americano.domain.postcard.repository;
 
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
-import com.bookbla.americano.domain.postcard.repository.entity.PostcardStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostcardRepository extends JpaRepository<Postcard, Long> {

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
@@ -4,7 +4,7 @@ import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
-import com.bookbla.americano.domain.quiz.QuizReply;
+import com.bookbla.americano.domain.quiz.repository.entity.QuizReply;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.postcard;
+package com.bookbla.americano.domain.postcard.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.Member;

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.postcard.repository.entity;
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.quiz.QuizReply;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/PostcardStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/PostcardStatus.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.postcard;
+package com.bookbla.americano.domain.postcard.repository.entity;
 
 public enum PostcardStatus {
     PENDING, ACCEPT, REFUSED, EXPIRED, ALL_WRONG

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/PostcardType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/PostcardType.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.postcard;
+package com.bookbla.americano.domain.postcard.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import javax.persistence.Entity;

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/request/QuizQuestionCreateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/request/QuizQuestionCreateRequest.java
@@ -1,7 +1,7 @@
 package com.bookbla.americano.domain.quiz.controller.dto.request;
 
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
-import com.bookbla.americano.domain.quiz.QuizQuestion;
+import com.bookbla.americano.domain.quiz.repository.entity.QuizQuestion;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/response/QuizQuestionReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/controller/dto/response/QuizQuestionReadResponse.java
@@ -1,6 +1,6 @@
 package com.bookbla.americano.domain.quiz.controller.dto.response;
 
-import com.bookbla.americano.domain.quiz.QuizQuestion;
+import com.bookbla.americano.domain.quiz.repository.entity.QuizQuestion;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/bookbla/americano/domain/quiz/enums/AnswerChoice.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/enums/AnswerChoice.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.quiz;
+package com.bookbla.americano.domain.quiz.enums;
 
 public enum AnswerChoice {
     FIRST,

--- a/src/main/java/com/bookbla/americano/domain/quiz/enums/CorrectStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/enums/CorrectStatus.java
@@ -1,4 +1,4 @@
-package com.bookbla.americano.domain.quiz;
+package com.bookbla.americano.domain.quiz.enums;
 
 public enum CorrectStatus {
     CORRECT, WRONG

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizQuestionRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizQuestionRepository.java
@@ -1,7 +1,7 @@
 package com.bookbla.americano.domain.quiz.repository;
 
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
-import com.bookbla.americano.domain.quiz.QuizQuestion;
+import com.bookbla.americano.domain.quiz.repository.entity.QuizQuestion;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizReplyRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizReplyRepository.java
@@ -1,7 +1,7 @@
 package com.bookbla.americano.domain.quiz.repository;
 
 
-import com.bookbla.americano.domain.quiz.QuizReply;
+import com.bookbla.americano.domain.quiz.repository.entity.QuizReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizReplyRepository extends JpaRepository<QuizReply, Long> {

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/entity/QuizQuestion.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/entity/QuizQuestion.java
@@ -1,7 +1,8 @@
-package com.bookbla.americano.domain.quiz;
+package com.bookbla.americano.domain.quiz.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
+import com.bookbla.americano.domain.quiz.enums.AnswerChoice;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/entity/QuizReply.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/entity/QuizReply.java
@@ -1,7 +1,8 @@
-package com.bookbla.americano.domain.quiz;
+package com.bookbla.americano.domain.quiz.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.quiz.enums.CorrectStatus;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/QuizQuestionService.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/QuizQuestionService.java
@@ -1,6 +1,5 @@
 package com.bookbla.americano.domain.quiz.service;
 
-import com.bookbla.americano.domain.quiz.QuizQuestion;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.response.QuizQuestionReadResponse;

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
@@ -28,7 +28,8 @@ public class QuizQuestionServiceImpl implements QuizQuestionService {
     @Override
     public Long createQuizQuestion(
             Long memberId, Long memberBookId,
-            QuizQuestionCreateRequest quizQuestionCreateRequest) {
+            QuizQuestionCreateRequest quizQuestionCreateRequest
+    ) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
 

--- a/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/service/impl/QuizQuestionServiceImpl.java
@@ -5,7 +5,7 @@ import com.bookbla.americano.domain.member.repository.MemberBookRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
-import com.bookbla.americano.domain.quiz.QuizQuestion;
+import com.bookbla.americano.domain.quiz.repository.entity.QuizQuestion;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionCreateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.request.QuizQuestionUpdateRequest;
 import com.bookbla.americano.domain.quiz.controller.dto.response.QuizQuestionReadResponse;
@@ -59,8 +59,7 @@ public class QuizQuestionServiceImpl implements QuizQuestionService {
     @Override
     public void updateQuizQuestion(
             Long memberId, Long memberBookId,
-            QuizQuestionUpdateRequest quizQuestionUpdateRequest
-    ) {
+            QuizQuestionUpdateRequest quizQuestionUpdateRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
 

--- a/src/test/java/com/bookbla/americano/domain/member/service/MemberStyleServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/member/service/MemberStyleServiceTest.java
@@ -179,7 +179,7 @@ class MemberStyleServiceTest {
         memberStyleService.updateMemberStyle(member.getId(), memberStyleUpdateRequest);
 
         // then
-        MemberStyle memberStyle = memberStyleRepository.getByMemberOrThrow(member);
+        MemberStyle memberStyle = memberStyleRepository.findByMember(member).orElseThrow();
         assertAll(
                 () -> assertThat(memberStyle.getDateStyleType()).isEqualTo(HOME),
                 () -> assertThat(memberStyle.getMbti()).isEqualTo(INFJ),

--- a/src/test/java/com/bookbla/americano/domain/memberask/service/MemberAskServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/memberask/service/MemberAskServiceTest.java
@@ -111,7 +111,7 @@ class MemberAskServiceTest {
         memberAskService.updateMemberAsk(member.getId(), memberAskUpdateRequest);
 
         // then
-        MemberAsk updatedMemberAsk = memberAskRepository.getByMemberOrThrow(member);
+        MemberAsk updatedMemberAsk = memberAskRepository.findByMember(member).orElseThrow();
         assertThat(updatedMemberAsk.getContents()).isEqualTo("어느 시간대에 책을 읽는 편이세요?");
     }
 


### PR DESCRIPTION
## 📄 Summary

> 만 하려고 했는데... 보이는거 몇개 더 했습니다

1. repository 내에서 getBy~ 형태로 감싸서 보내는 디폴트 메서드들... getByIdOrThrow() 형태만 남기고 나머지 다 없앴습니다(제목 내용)
2. PostCard 내 `recive` -> `receive` 오타 수정했습니다
3. PostCardRepository를 postcard 패키지로 이동했습니다
4. member 패키지 다이어트의 시발점으로.. policy 패키지 하나 만들어서 엔티티랑 레파지토리만 빼뒀습니다

## 🙋🏻 More

>