### PR TITLE
feat: 대표 책 삭제시 가장 이전에 등록한 책을 대표책으로 바꾸는 기능 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/base/entity/BaseInsertEntity.java
+++ b/src/main/java/com/bookbla/americano/base/entity/BaseInsertEntity.java
@@ -4,12 +4,14 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseInsertEntity {
 
     @CreatedDate

--- a/src/main/java/com/bookbla/americano/domain/book/infra/kakao/dto/KakaoBookResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/book/infra/kakao/dto/KakaoBookResponse.java
@@ -47,7 +47,7 @@ public class KakaoBookResponse {
                 .map(it -> new BookSearchResponse(it.title, it.authors, it.isbn, it.thumbnail))
                 .collect(Collectors.toList());
         return BookSearchResponses.builder()
-                .totalCount(getMeta().totalCount)
+                .totalCount(getMeta().pageableCount)
                 .page(page)
                 .isEnd(getMeta().isEnd())
                 .bookSearchResponses(bookSearchResponses)

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
@@ -75,5 +75,4 @@ public class MemberBookController {
         memberBookService.deleteMemberBook(loginUser.getMemberId(), memberBookId);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberBookController.java
@@ -50,9 +50,11 @@ public class MemberBookController {
     }
 
     @GetMapping("/{memberBookId}")
-    public ResponseEntity<MemberBookReadResponse> readMemberBook(@PathVariable Long memberBookId) {
-        MemberBookReadResponse memberBookReadResponse = memberBookService.readMemberBook(
-            memberBookId);
+    public ResponseEntity<MemberBookReadResponse> readMemberBook(
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @PathVariable Long memberBookId
+    ) {
+        MemberBookReadResponse memberBookReadResponse = memberBookService.readMemberBook(loginUser.getMemberId(), memberBookId);
         return ResponseEntity.ok(memberBookReadResponse);
     }
 

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleCreateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleCreateRequest.java
@@ -8,13 +8,16 @@ import com.bookbla.americano.domain.member.enums.DrinkType;
 import com.bookbla.americano.domain.member.enums.JustFriendType;
 import com.bookbla.americano.domain.member.enums.Mbti;
 import com.bookbla.americano.domain.member.enums.SmokeType;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
+@Getter
 public class MemberStyleCreateRequest {
 
     @NotNull(message = "mbti가 입력되지 않았습니다.")
@@ -38,7 +41,7 @@ public class MemberStyleCreateRequest {
     @NotNull(message = "데이트 스타일이 입력되지 않았습니다.")
     private String dateStyleType;
 
-    @NotNull(message = "개인 질문이 입력되지 않았습니다.")
+    @NotBlank(message = "개인 질문이 입력되지 않았습니다.")
     private String memberAsk;
 
     public MemberStyle toMemberStyle() {
@@ -51,9 +54,5 @@ public class MemberStyleCreateRequest {
                 .justFriendType(JustFriendType.from(justFriendType))
                 .dateCostType(DateCostType.from(dateCostType))
                 .build();
-    }
-
-    public String getMemberAsk() {
-        return memberAsk;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStyleUpdateRequest.java
@@ -7,6 +7,7 @@ import com.bookbla.americano.domain.member.enums.DrinkType;
 import com.bookbla.americano.domain.member.enums.JustFriendType;
 import com.bookbla.americano.domain.member.enums.Mbti;
 import com.bookbla.americano.domain.member.enums.SmokeType;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -37,7 +38,7 @@ public class MemberStyleUpdateRequest {
     @NotNull(message = "데이트 스타일이 입력되지 않았습니다.")
     private String dateStyleType;
 
-    @NotNull(message = "개인 질문이 입력되지 않았습니다.")
+    @NotBlank(message = "개인 질문이 입력되지 않았습니다.")
     private String memberAsk;
 
     public Mbti getMbti() {

--- a/src/main/java/com/bookbla/americano/domain/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/member/exception/MemberExceptionType.java
@@ -25,7 +25,7 @@ public enum MemberExceptionType implements ExceptionType {
     GENDER_NOT_VALID(HttpStatus.BAD_REQUEST, "member_012", "유효하지 않은 성별입니다."),
     AUTH_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "member_013", "인증이 등록되지 않은 회원입니다."),
     PROFILE_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "member_014", "프로필이 등록되지 않은 회원입니다."),
-    ;
+    STYLE_ALREADY_REGISTERD(HttpStatus.BAD_REQUEST, "membrt_015", "스타일이 이미 등록된 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberBookRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberBookRepository.java
@@ -22,6 +22,5 @@ public interface MemberBookRepository extends JpaRepository<MemberBook, Long> {
 
     long countByMember(Member member);
 
-    List<MemberBook> findByMember(Member member);
-
+    List<MemberBook> findByMemberOrderByCreatedAt(Member member);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/Member.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/Member.java
@@ -124,4 +124,10 @@ public class Member extends BaseInsertEntity {
         }
         return memberPolicy;
     }
+
+    public void validateStyleRegistered() {
+        if (this.memberStyle == null) {
+            throw new BaseException(MemberExceptionType.STYLE_NOT_REGISTERED);
+        }
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/Member.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/Member.java
@@ -126,8 +126,8 @@ public class Member extends BaseInsertEntity {
     }
 
     public void validateStyleRegistered() {
-        if (this.memberStyle == null) {
-            throw new BaseException(MemberExceptionType.STYLE_NOT_REGISTERED);
+        if (this.memberStyle != null) {
+            throw new BaseException(MemberExceptionType.STYLE_ALREADY_REGISTERD);
         }
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBook.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBook.java
@@ -63,7 +63,11 @@ public class MemberBook extends BaseInsertEntity {
         this.review = review;
     }
 
-    public void represent() {
+    public boolean isNotRepresentative() {
+        return this.isRepresentative == false;
+    }
+
+    public void updateRepresentative() {
         this.isRepresentative = true;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBook.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBook.java
@@ -43,7 +43,8 @@ public class MemberBook extends BaseInsertEntity {
 
     private String review;
 
-    private boolean isRepresentative;
+    @Builder.Default
+    private boolean isRepresentative = false;
 
     public void validateOwner(Member other) {
         if (!this.member.equals(other)) {
@@ -60,5 +61,9 @@ public class MemberBook extends BaseInsertEntity {
             throw new BaseException(MemberBookExceptionType.REVIEW_LENGTH_NOT_VALID);
         }
         this.review = review;
+    }
+
+    public void represent() {
+        this.isRepresentative = true;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberBookService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberBookService.java
@@ -12,7 +12,7 @@ public interface MemberBookService {
 
     MemberBookReadResponses readMemberBooks(Long memberId);
 
-    MemberBookReadResponse readMemberBook(Long memberBookId);
+    MemberBookReadResponse readMemberBook(Long memberId, Long memberBookId);
 
     void deleteMemberBook(Long memberId, Long memberBookId);
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -70,8 +70,12 @@ public class MemberBookServiceImpl implements MemberBookService {
 
     @Override
     @Transactional(readOnly = true)
-    public MemberBookReadResponse readMemberBook(Long memberBookId) {
+    public MemberBookReadResponse readMemberBook(Long memberId, Long memberBookId) {
+        Member member = memberRepository.getByIdOrThrow(memberId);
         MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
+
+        memberBook.validateOwner(member);
+
         return MemberBookReadResponse.of(memberBook);
     }
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -96,7 +96,7 @@ public class MemberBookServiceImpl implements MemberBookService {
 
         memberBook.validateOwner(member);
 
-        if (!memberBook.isRepresentative()) {
+        if (memberBook.isNotRepresentative()) {
             memberBookRepository.deleteById(memberBookId);
             return;
         }
@@ -104,7 +104,7 @@ public class MemberBookServiceImpl implements MemberBookService {
         memberBookRepository.deleteById(memberBookId);
         List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
         if (!memberBooks.isEmpty()) {
-            memberBooks.get(OLD_MEMBER_BOOK).represent();
+            memberBooks.get(OLD_MEMBER_BOOK).updateRepresentative();
         }
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -27,6 +27,8 @@ import static com.bookbla.americano.domain.member.repository.entity.MemberBook.M
 @RequiredArgsConstructor
 public class MemberBookServiceImpl implements MemberBookService {
 
+    private static final int OLD_MEMBER_BOOK = 0;
+
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
     private final MemberBookRepository memberBookRepository;
@@ -102,7 +104,7 @@ public class MemberBookServiceImpl implements MemberBookService {
         memberBookRepository.deleteById(memberBookId);
         List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
         if (!memberBooks.isEmpty()) {
-            memberBooks.get(0).represent();
+            memberBooks.get(OLD_MEMBER_BOOK).represent();
         }
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -62,7 +62,7 @@ public class MemberBookServiceImpl implements MemberBookService {
     @Transactional(readOnly = true)
     public MemberBookReadResponses readMemberBooks(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
-        List<MemberBook> memberBooks = memberBookRepository.findByMember(member);
+        List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
         return MemberBookReadResponses.from(memberBooks);
     }
 
@@ -94,6 +94,15 @@ public class MemberBookServiceImpl implements MemberBookService {
 
         memberBook.validateOwner(member);
 
+        if (!memberBook.isRepresentative()) {
+            memberBookRepository.deleteById(memberBookId);
+            return;
+        }
+
         memberBookRepository.deleteById(memberBookId);
+        List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
+        if (!memberBooks.isEmpty()) {
+            memberBooks.get(0).represent();
+        }
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -29,7 +29,7 @@ public class MemberLibraryServiceImpl implements MemberLibraryService {
     public MemberLibraryProfileReadResponse getLibraryProfile(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberProfile memberProfile = member.getMemberProfile();
-        List<MemberBook> memberBooks = memberBookRepository.findByMember(member);
+        List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
 
         return MemberLibraryProfileReadResponse.of(member, memberProfile, memberBooks);
     }
@@ -39,7 +39,7 @@ public class MemberLibraryServiceImpl implements MemberLibraryService {
     public MemberTargetLibraryProfileReadResponse getTargetLibraryProfile(Long memberId, Long targetMemberId) {
         Member targetMember = memberRepository.getByIdOrThrow(targetMemberId);
         MemberProfile memberProfile = targetMember.getMemberProfile();
-        List<MemberBook> memberBooks = memberBookRepository.findByMember(targetMember);
+        List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(targetMember);
 
         boolean isMatched = false;
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberStyleServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberStyleServiceImpl.java
@@ -4,6 +4,7 @@ import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberStyleCreateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberStyleUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberStyleResponse;
+import com.bookbla.americano.domain.member.enums.MemberStatus;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberStyle;
@@ -41,6 +42,8 @@ public class MemberStyleServiceImpl implements MemberStyleService {
     @Override
     public MemberStyleResponse createMemberStyle(Long memberId, MemberStyleCreateRequest memberStyleCreateRequest) {
         Member member = memberRepository.getByIdOrThrow(memberId);
+        member.validateStyleRegistered();
+
         member.updateMemberStyle(memberStyleCreateRequest.toMemberStyle());
 
         MemberAsk memberAsk = MemberAsk.builder()

--- a/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/request/MemberAskCreateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/request/MemberAskCreateRequest.java
@@ -2,7 +2,7 @@ package com.bookbla.americano.domain.memberask.controller.dto.request;
 
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -12,8 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberAskCreateRequest {
 
-    // 등록하지 않을 수도 있나?
-    @NotNull(message = "개인 질문이 입력되지 않았습니다.")
+    @NotBlank(message = "개인 질문이 입력되지 않았습니다.")
     private String contents;
 
     public MemberAsk toMemberAskWith(Member member) {

--- a/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/request/MemberAskUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/request/MemberAskUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.bookbla.americano.domain.memberask.controller.dto.request;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,8 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberAskUpdateRequest {
 
-    // 등록하지 않을 수도 있나?
-    @NotNull(message = "개인 질문이 입력되지 않았습니다.")
+    @NotBlank(message = "개인 질문이 입력되지 않았습니다.")
     private String contents;
 
 }

--- a/src/test/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceTest.java
@@ -1,0 +1,65 @@
+package com.bookbla.americano.domain.member.service.impl;
+
+import java.util.List;
+
+import com.bookbla.americano.domain.book.repository.BookRepository;
+import com.bookbla.americano.domain.book.repository.entity.Book;
+import com.bookbla.americano.domain.member.repository.MemberBookRepository;
+import com.bookbla.americano.domain.member.repository.MemberRepository;
+import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.member.repository.entity.MemberBook;
+import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
+import com.bookbla.americano.domain.member.service.MemberBookService;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest
+@Transactional
+class MemberBookServiceTest {
+
+    @Autowired
+    private MemberBookService memberBookService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private MemberBookRepository memberBookRepository;
+
+    @Test
+    void 회원의_대표책_삭제시_두번째로_등록된_책이_대표책이_된다() {
+        // given
+        Book firstBook = bookRepository.save(Book.builder().isbn("1").title("오브젝트").build());
+        Book secondBook = bookRepository.save(Book.builder().isbn("2").title("DDD").build());
+        Book thirdBook = bookRepository.save(Book.builder().isbn("3").title("클린아키텍처").build());
+
+        Member member = memberRepository.save(Member.builder().memberProfile(MemberProfile.builder().name("이준희").build()).build());
+
+        MemberBook memberBook = memberBookRepository.save(MemberBook.builder().book(firstBook).isRepresentative(true).member(member).build());
+        memberBookRepository.save(MemberBook.builder().book(secondBook).member(member).build());
+        memberBookRepository.save(MemberBook.builder().book(thirdBook).member(member).build());
+
+        // when
+        memberBookService.deleteMemberBook(member.getId(), memberBook.getId());
+
+        // then
+        List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
+        assertAll(
+                () -> assertThat(memberBooks).hasSize(2),
+                () -> assertThat(memberBooks.get(0).isRepresentative()).isTrue(),
+                () -> assertThat(memberBooks.get(1).isRepresentative()).isFalse()
+        );
+    }
+}


### PR DESCRIPTION
## 📄 Summary

> 디스코드에서 언급된 대표책 삭제시 이전에 등록한 책을 대표책으로 바꾸는 기능을 추가하였습니당

작업내역은
1. `MemberBookService.deleteMemberBook()` 내 로직 추가
2. 회원이 등록한 도서 가져올 때 명시적으로 createdAt 순서로 가져오도록 변경
3. 테스트

입니다

## 🙋🏻 More

>