### PR TITLE
Feat: Home(다른 사용자 전체 list 전송 api 추가) / Matching(보낸 엽서, 받은 엽서 보기를 위한 api 추가)

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberController.java
@@ -4,17 +4,15 @@ import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookProfileRequestDto;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberUpdateRequest;
-import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponseDto;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberDeleteResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberStatusResponse;
 import com.bookbla.americano.domain.member.service.MemberPostcardService;
 import com.bookbla.americano.domain.member.service.MemberProfileService;
 import com.bookbla.americano.domain.member.service.MemberService;
-import com.sun.source.tree.MemberReferenceTree;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -23,7 +21,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -82,11 +79,11 @@ public class MemberController {
     }
 
     @GetMapping("/same-book-members")
-    public ResponseEntity<Page<MemberBookProfileResponseDto>> sameBookMembersPage(
+    public ResponseEntity<Page<MemberBookProfileResponse>> sameBookMembersPage(
         @Parameter(hidden = true) @User LoginUser loginUser,
         @ModelAttribute MemberBookProfileRequestDto memberBookProfileRequestDto,
         Pageable pageable) {
-        List<MemberBookProfileResponseDto> memberBookProfileResponseList = memberProfileService.findSameBookMembers(
+        List<MemberBookProfileResponse> memberBookProfileResponseList = memberProfileService.findSameBookMembers(
             loginUser.getMemberId(), memberBookProfileRequestDto);
         if (pageable == null) {
             pageable = PageRequest.of(0, 0);
@@ -94,13 +91,36 @@ public class MemberController {
 
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), memberBookProfileResponseList.size());
-        Page<MemberBookProfileResponseDto> memberBookProfileResponsePage;
+        Page<MemberBookProfileResponse> memberBookProfileResponsePage;
         if (start >= memberBookProfileResponseList.size()) {
             memberBookProfileResponsePage = Page.empty();
         } else {
             memberBookProfileResponsePage = new PageImpl<>(
                 memberBookProfileResponseList.subList(start, end), pageable,
                 memberBookProfileResponseList.size());
+        }
+        return ResponseEntity.ok(memberBookProfileResponsePage);
+    }
+
+    @GetMapping("/all-other-members")
+    public ResponseEntity<Page<MemberBookProfileResponse>> getAllMembersProfile(
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @ModelAttribute MemberBookProfileRequestDto memberBookProfileRequestDto,
+            Pageable pageable) {
+        List<MemberBookProfileResponse> result = memberProfileService.getAllMembers(loginUser.getMemberId(), memberBookProfileRequestDto);
+        if (pageable == null) {
+            pageable = PageRequest.of(0, 0);
+        }
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), result.size());
+        Page<MemberBookProfileResponse> memberBookProfileResponsePage;
+        if (start >= result.size()) {
+            memberBookProfileResponsePage = Page.empty();
+        } else {
+            memberBookProfileResponsePage = new PageImpl<>(
+                    result.subList(start, end), pageable,
+                    result.size());
         }
         return ResponseEntity.ok(memberBookProfileResponsePage);
     }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberBookProfileResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberBookProfileResponse.java
@@ -14,7 +14,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-public class MemberBookProfileResponseDto {
+public class MemberBookProfileResponse {
 
     private long memberId;
 

--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberPostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberPostcardRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface MemberPostcardRepository extends JpaRepository<MemberPostcard, Long> {
     Optional<MemberPostcard> findMemberPostcardByMemberId(@Param("memberId") Long memberId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE MemberPostcard mp SET mp.freePostcardCount = 1")
     void initMemberFreePostcardCount();
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/custom/MemberRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/custom/MemberRepositoryCustom.java
@@ -1,10 +1,11 @@
 package com.bookbla.americano.domain.member.repository.custom;
 
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookProfileRequestDto;
-import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponseDto;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponse;
 
 import java.util.List;
 
 public interface MemberRepositoryCustom {
-    List<MemberBookProfileResponseDto> searchSameBookMember(Long memberId, MemberBookProfileRequestDto requestDto);
+    List<MemberBookProfileResponse> searchSameBookMember(Long memberId, MemberBookProfileRequestDto requestDto);
+    List<MemberBookProfileResponse> getAllMembers(Long memberId, MemberBookProfileRequestDto requestDto);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberPostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberPostcardService.java
@@ -1,5 +1,9 @@
 package com.bookbla.americano.domain.member.service;
 
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardResponse;
+
 public interface MemberPostcardService {
     int getMemberPostcardCount(Long memberId);
+
+    MemberPostcardResponse getMemberPostcardEachCount(Long memberId);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberProfileService.java
@@ -1,19 +1,20 @@
 package com.bookbla.americano.domain.member.service;
 
-import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileStatusUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookProfileRequestDto;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileUpdateRequest;
-import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponseDto;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileStatusResponse;
 import com.bookbla.americano.domain.member.service.dto.MemberProfileDto;
-
 import com.bookbla.americano.domain.member.service.dto.MemberProfileStatusDto;
+
 import java.util.List;
 
 public interface MemberProfileService {
 
-    List<MemberBookProfileResponseDto> findSameBookMembers(Long memberId, MemberBookProfileRequestDto memberBookProfileRequestDto);
+    List<MemberBookProfileResponse> findSameBookMembers(Long memberId, MemberBookProfileRequestDto memberBookProfileRequestDto);
+
+    List<MemberBookProfileResponse> getAllMembers(Long memberId, MemberBookProfileRequestDto requestDto);
 
     MemberProfileResponse createMemberProfile(Long memberId, MemberProfileDto memberProfileDto);
 
@@ -24,6 +25,6 @@ public interface MemberProfileService {
     MemberProfileStatusResponse readMemberProfileStatus(Long memberId);
 
     MemberProfileStatusResponse updateMemberProfileStatus(Long memberId,
-        MemberProfileStatusDto memberProfileStatusDto);
+                                                          MemberProfileStatusDto memberProfileStatusDto);
 
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberPostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberPostcardServiceImpl.java
@@ -5,6 +5,7 @@ import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberPostcardRepository;
 import com.bookbla.americano.domain.member.repository.entity.MemberPostcard;
 import com.bookbla.americano.domain.member.service.MemberPostcardService;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +13,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MemberPostcardServiceImpl implements MemberPostcardService {
     private final MemberPostcardRepository memberPostcardRepository;
+
+    @Override
+    public MemberPostcardResponse getMemberPostcardEachCount(Long memberId) {
+        MemberPostcard result = memberPostcardRepository.findMemberPostcardByMemberId(memberId)
+                .orElseThrow(() -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
+        return new MemberPostcardResponse(result.getFreePostcardCount(), result.getPayPostcardCount());
+    }
 
     @Override
     public int getMemberPostcardCount(Long memberId) {

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -2,24 +2,69 @@ package com.bookbla.americano.domain.postcard.controller;
 
 import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
-import com.bookbla.americano.domain.book.service.dto.BookSearchResponses;
+import com.bookbla.americano.domain.member.service.MemberPostcardService;
+import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
+import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
 import com.bookbla.americano.domain.postcard.service.PostcardService;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
+@Transactional
 @RequestMapping("/postcard")
 @RequiredArgsConstructor
 public class PostcardController {
-
     private final PostcardService postcardService;
+    private final MemberPostcardService memberPostcardService;
+
+    @Operation(summary = "사용자 Postcard 타입 별 개수 조회", description = "Free Postcard / Pay Postcard 타입 별 개수 조회")
+    @GetMapping("")
+    public ResponseEntity<MemberPostcardResponse> getMemberPostcardCount(@Parameter(hidden = true) @User LoginUser loginUser) {
+        return ResponseEntity.ok(memberPostcardService.getMemberPostcardEachCount(loginUser.getMemberId()));
+    }
+
+    @Operation(summary = "보낸 엽서 조회", description = "사용자가 보낸 엽서 조회")
+    @GetMapping("/from")
+    public ResponseEntity<List<MemberPostcardFromResponse>> readPostcardsFromMember(@Parameter(hidden = true) @User LoginUser loginUser) {
+        return ResponseEntity.ok(postcardService.getPostcardsFromMember(loginUser.getMemberId()));
+    }
+
+    @Operation(summary = "받은 엽서 조회", description = "사용자가 받은 엽서 조회")
+    @GetMapping("/to")
+    public ResponseEntity<List<MemberPostcardToResponse>> readPostcardsToMember(@Parameter(hidden = true) @User LoginUser loginUser) {
+        return ResponseEntity.ok(postcardService.getPostcardsToMember(loginUser.getMemberId()));
+    }
+
+    @Operation(summary = "엽서 사용", description = "{payType}에 따라 무료 엽서 또는 유료 엽서 1개 사용. payType : FREE / PAY")
+    @PatchMapping("/{payType}")
+    public void usePostcard(@Parameter(hidden = true) @User LoginUser loginUser, @PathVariable PostcardPayType payType) {
+        postcardService.useMemberPostcard(loginUser.getMemberId(), payType);
+    }
+
+    @Operation(summary = "Postcard 상태 업데이트", description = "{postcardId}를 가진 엽서의 상태 업데이트. Body의 status 값으로 해당 엽서의 상태(PostcardStatus)를 변경함.")
+    @PostMapping("/status/{postcardId}")
+    public void updatePostcardStatus(@PathVariable Long postcardId, @RequestBody @Valid PostcardStatusUpdateRequest request) {
+        postcardService.updatePostcardStatus(postcardId, request);
+    }
 
     @PostMapping("/send")
     public ResponseEntity<SendPostcardResponse> sendPostcard(

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -1,5 +1,6 @@
 package com.bookbla.americano.domain.postcard.controller;
 
+import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.member.service.MemberPostcardService;
@@ -8,6 +9,7 @@ import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostc
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
 import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
 import com.bookbla.americano.domain.postcard.service.PostcardService;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
@@ -16,7 +18,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,7 +30,6 @@ import javax.validation.Valid;
 import java.util.List;
 
 @RestController
-@Transactional
 @RequestMapping("/postcard")
 @RequiredArgsConstructor
 public class PostcardController {
@@ -56,8 +56,14 @@ public class PostcardController {
 
     @Operation(summary = "엽서 사용", description = "{payType}에 따라 무료 엽서 또는 유료 엽서 1개 사용. payType : FREE / PAY")
     @PatchMapping("/{payType}")
-    public void usePostcard(@Parameter(hidden = true) @User LoginUser loginUser, @PathVariable PostcardPayType payType) {
-        postcardService.useMemberPostcard(loginUser.getMemberId(), payType);
+    public void usePostcard(@Parameter(hidden = true) @User LoginUser loginUser, @PathVariable String payType) {
+        try{
+            PostcardPayType postcardPayType = PostcardPayType.valueOf(payType.toUpperCase());
+            postcardService.useMemberPostcard(loginUser.getMemberId(), postcardPayType);
+        } catch (IllegalArgumentException e){
+            throw new BaseException(PostcardExceptionType.INVALID_PAY_TYPE);
+        }
+
     }
 
     @Operation(summary = "Postcard 상태 업데이트", description = "{postcardId}를 가진 엽서의 상태 업데이트. Body의 status 값으로 해당 엽서의 상태(PostcardStatus)를 변경함.")

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/request/PostcardStatusUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/request/PostcardStatusUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.bookbla.americano.domain.postcard.controller.dto.request;
+
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class PostcardStatusUpdateRequest {
+    @NotNull
+    private PostcardStatus status;
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardFromResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardFromResponse.java
@@ -1,0 +1,59 @@
+package com.bookbla.americano.domain.postcard.controller.dto.response;
+
+import com.bookbla.americano.domain.member.enums.Gender;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+// 보낸 엽서
+public class MemberPostcardFromResponse {
+
+    // Member 정보
+    private long memberId;
+
+    private String memberName;
+
+    private int memberAge;
+
+    private Gender memberGender;
+
+    private String memberSchoolName;
+
+    private String memberProfileImageUrl;
+
+    private String memberOpenKakaoRoomUrl;
+
+    // 책 정보
+    private String representativeBookTitle;
+
+    private List<String> representativeBookAuthor;
+
+    private List<String> bookImageUrls;
+
+    // 엽서 정보
+    private PostcardStatus postcardStatus;
+
+    public MemberPostcardFromResponse(long memberId, String memberName, int memberAge, Gender memberGender, String memberSchoolName,
+                                      String memberProfileImageUrl, String memberOpenKakaoRoomUrl, PostcardStatus postcardStatus) {
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.memberAge = memberAge;
+        this.memberGender = memberGender;
+        this.memberSchoolName = memberSchoolName;
+        this.memberProfileImageUrl = memberProfileImageUrl;
+        this.memberOpenKakaoRoomUrl = memberOpenKakaoRoomUrl;
+        this.postcardStatus = postcardStatus;
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardResponse.java
@@ -1,0 +1,19 @@
+package com.bookbla.americano.domain.postcard.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class MemberPostcardResponse {
+    private int freePostcardCount;
+    private int payPostcardCount;
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardToResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardToResponse.java
@@ -1,0 +1,88 @@
+package com.bookbla.americano.domain.postcard.controller.dto.response;
+
+import com.bookbla.americano.domain.member.enums.ContactType;
+import com.bookbla.americano.domain.member.enums.DateCostType;
+import com.bookbla.americano.domain.member.enums.DateStyleType;
+import com.bookbla.americano.domain.member.enums.DrinkType;
+import com.bookbla.americano.domain.member.enums.Gender;
+import com.bookbla.americano.domain.member.enums.JustFriendType;
+import com.bookbla.americano.domain.member.enums.Mbti;
+import com.bookbla.americano.domain.member.enums.SmokeType;
+import com.bookbla.americano.domain.quiz.enums.CorrectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+// 받은 엽서
+public class MemberPostcardToResponse {
+
+    private long postcardId;
+
+    private long memberId;
+
+    private String memberName;
+
+    private String memberProfileImageUrl;
+
+    private int memberAge;
+
+    private Gender memberGender;
+
+    private DrinkType drinkType;
+
+    private SmokeType smokeType;
+
+    private ContactType contactType;
+
+    private DateStyleType dateStyleType;
+
+    private DateCostType dateCostType;
+
+    private Mbti mbti;
+
+    private JustFriendType justFriendType;
+
+    private String memberSchoolName;
+
+    private int quizScore;
+
+    // 책 제목
+    private List<String> bookTitles;
+
+    // 독서 퀴즈 답
+    private List<CorrectStatus> correctStatuses;
+
+    // 개인 질문 답
+    private String memberReplyContent;
+
+    public MemberPostcardToResponse(long postcardId, long memberId, String memberName, String memberProfileImageUrl,
+                                    int memberAge, Gender memberGender, DrinkType drinkType, SmokeType smokeType,
+                                    ContactType contactType, DateStyleType dateStyleType, DateCostType dateCostType,
+                                    Mbti mbti, JustFriendType justFriendType, String memberSchoolName, String memberReplyContent) {
+
+        this.postcardId = postcardId;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.memberProfileImageUrl = memberProfileImageUrl;
+        this.memberAge = memberAge;
+        this.memberGender = memberGender;
+        this.drinkType = drinkType;
+        this.smokeType = smokeType;
+        this.contactType = contactType;
+        this.dateStyleType = dateStyleType;
+        this.dateCostType = dateCostType;
+        this.mbti = mbti;
+        this.justFriendType = justFriendType;
+        this.memberSchoolName = memberSchoolName;
+        this.memberReplyContent = memberReplyContent;
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardPayType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardPayType.java
@@ -1,0 +1,5 @@
+package com.bookbla.americano.domain.postcard.enums;
+
+public enum PostcardPayType {
+    FREE, PAY
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 public enum PostcardExceptionType implements ExceptionType {
 
     POSTCARD_TYPE_NOT_VALID(HttpStatus.NOT_FOUND, "postcard_001", "유효하지 않은 엽서 타입입니다."),
-    INVALID_TYPE(HttpStatus.BAD_REQUEST, "member-profile_002", "유효하지 않은 Postcard 타입입니다."),
+    INVALID_PAY_TYPE(HttpStatus.BAD_REQUEST, "postcard_002", "유효하지 않은 엽서 가격 유형입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PostcardExceptionType implements ExceptionType {
 
-    POSTCARD_TYPE_NOT_VALID(HttpStatus.NOT_FOUND, "postcard_001", "유효하지 않은 엽서 타입입니다."),;
+    POSTCARD_TYPE_NOT_VALID(HttpStatus.NOT_FOUND, "postcard_001", "유효하지 않은 엽서 타입입니다."),
+    INVALID_TYPE(HttpStatus.BAD_REQUEST, "member-profile_002", "유효하지 않은 Postcard 타입입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
@@ -1,9 +1,25 @@
 package com.bookbla.americano.domain.postcard.repository;
 
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import com.bookbla.americano.domain.postcard.repository.custom.PostcardRepositoryCustom;
 import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface PostcardRepository extends JpaRepository<Postcard, Long> {
+public interface PostcardRepository extends JpaRepository<Postcard, Long>, PostcardRepositoryCustom {
     boolean existsBySendMemberIdAndReceiveMemberIdAndPostcardStatus(Long sendMemberId, Long receiveMemberId, PostcardStatus status);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update MemberPostcard mp set mp.freePostcardCount = mp.freePostcardCount - 1 where mp.member.id = :memberId")
+    void useMemberFreePostcard(@Param("memberId") Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update MemberPostcard mp set mp.payPostcardCount = mp.payPostcardCount - 1 where mp.member.id = :memberId")
+    void useMemberPayPostcard(@Param("memberId") Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Postcard p set p.postcardStatus = :status where p.id = :postcardId")
+    void updatePostcardStatus(@Param("status") PostcardStatus status, @Param("postcardId") Long postcardId);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
@@ -11,15 +11,15 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostcardRepository extends JpaRepository<Postcard, Long>, PostcardRepositoryCustom {
     boolean existsBySendMemberIdAndReceiveMemberIdAndPostcardStatus(Long sendMemberId, Long receiveMemberId, PostcardStatus status);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update MemberPostcard mp set mp.freePostcardCount = mp.freePostcardCount - 1 where mp.member.id = :memberId")
     void useMemberFreePostcard(@Param("memberId") Long memberId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update MemberPostcard mp set mp.payPostcardCount = mp.payPostcardCount - 1 where mp.member.id = :memberId")
     void useMemberPayPostcard(@Param("memberId") Long memberId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Postcard p set p.postcardStatus = :status where p.id = :postcardId")
     void updatePostcardStatus(@Param("status") PostcardStatus status, @Param("postcardId") Long postcardId);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/PostcardRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/PostcardRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.bookbla.americano.domain.postcard.repository.custom;
+
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
+
+import java.util.List;
+
+public interface PostcardRepositoryCustom {
+    List<PostcardFromResponse> getPostcardsFromMember(Long memberId);
+
+    List<PostcardToResponse> getPostcardsToMember(Long memberId);
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -1,0 +1,90 @@
+package com.bookbla.americano.domain.postcard.repository.custom.impl;
+
+import com.bookbla.americano.domain.book.repository.entity.QBook;
+import com.bookbla.americano.domain.member.repository.entity.QMember;
+import com.bookbla.americano.domain.member.repository.entity.QMemberBook;
+import com.bookbla.americano.domain.memberask.repository.entity.QMemberAsk;
+import com.bookbla.americano.domain.memberask.repository.entity.QMemberReply;
+import com.bookbla.americano.domain.postcard.repository.custom.PostcardRepositoryCustom;
+import com.bookbla.americano.domain.postcard.repository.entity.QPostcard;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
+import com.bookbla.americano.domain.quiz.repository.entity.QQuizQuestion;
+import com.bookbla.americano.domain.quiz.repository.entity.QQuizReply;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PostcardFromResponse> getPostcardsFromMember(Long memberId) {
+        QMember member = QMember.member;
+        QPostcard postcard = QPostcard.postcard;
+
+        return queryFactory.select(Projections.fields(PostcardFromResponse.class
+                        , postcard.receiveMember.id.as("memberId")
+                        , postcard.receiveMember.memberProfile.name.as("memberName")
+                        , postcard.receiveMember.memberProfile.birthDate.as("memberBirthDate")
+                        , postcard.receiveMember.memberProfile.gender.as("memberGender")
+                        , postcard.receiveMember.memberProfile.schoolName.as("memberSchoolName")
+                        , postcard.receiveMember.memberProfile.profileImageUrl.as("memberProfileImageUrl")
+                        , postcard.receiveMember.memberProfile.openKakaoRoomUrl.as("memberOpenKakaoRoomUrl")
+                        , postcard.postcardStatus.as("postcardStatus"))
+                )
+                .from(postcard)
+                .innerJoin(member).on(postcard.receiveMember.eq(member))
+                .where(postcard.sendMember.id.eq(memberId))
+                .orderBy(postcard.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<PostcardToResponse> getPostcardsToMember(Long memberId) {
+        QMember member = QMember.member;
+        QMemberBook memberBook = QMemberBook.memberBook;
+        QPostcard postcard = QPostcard.postcard;
+        QBook book = QBook.book;
+        QQuizQuestion quizQuestion = QQuizQuestion.quizQuestion;
+        QQuizReply quizReply = QQuizReply.quizReply;
+        QMemberAsk memberAsk = QMemberAsk.memberAsk;
+        QMemberReply memberReply = QMemberReply.memberReply;
+
+        return queryFactory.select(Projections.fields(PostcardToResponse.class
+                        , postcard.id.as("postcardId")
+                        , postcard.sendMember.id.as("memberId")
+                        , postcard.sendMember.memberProfile.name.as("memberName")
+                        , postcard.sendMember.memberProfile.birthDate.as("memberBirthDate")
+                        , postcard.sendMember.memberProfile.gender.as("memberGender")
+                        , postcard.sendMember.memberProfile.schoolName.as("memberSchoolName")
+                        , postcard.sendMember.memberProfile.profileImageUrl.as("memberProfileImageUrl")
+                        , postcard.sendMember.memberStyle.drinkType
+                        , postcard.sendMember.memberStyle.smokeType
+                        , postcard.sendMember.memberStyle.contactType
+                        , postcard.sendMember.memberStyle.dateStyleType
+                        , postcard.sendMember.memberStyle.dateCostType
+                        , postcard.sendMember.memberStyle.mbti
+                        , postcard.sendMember.memberStyle.justFriendType
+                        , book.title.as("bookTitle")
+                        , quizReply.correctStatus
+                        , memberReply.content.as("memberReplyContent"))
+                )
+                .from(postcard)
+                .innerJoin(quizReply).on(postcard.eq(quizReply.postcard))
+                .innerJoin(quizQuestion).on(quizReply.quizQuestion.eq(quizQuestion))
+                .innerJoin(memberBook).on(quizQuestion.memberBook.eq(memberBook))
+                .innerJoin(book).on(memberBook.book.eq(book))
+                .innerJoin(member).on(memberBook.member.eq(member))
+                .innerJoin(memberAsk).on(member.eq(memberAsk.member))
+                .innerJoin(memberReply).on(postcard.memberReply.eq(memberReply))
+                .where(postcard.receiveMember.id.eq(memberId))
+                .orderBy(postcard.sendMember.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
@@ -4,7 +4,6 @@ import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
-import com.bookbla.americano.domain.quiz.repository.entity.QuizReply;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,7 +47,6 @@ public class Postcard extends BaseInsertEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "postcard_type_id")
     private PostcardType postcardType;
-
 
     private String imageUrl;
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -1,12 +1,25 @@
 package com.bookbla.americano.domain.postcard.service;
 
-
+import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
+import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
+
+import java.util.List;
 
 public interface PostcardService {
     SendPostcardResponse send(Long memberId, SendPostcardRequest sendPostcardRequest);
 
     PostcardTypeResponse getPostcardTypeList();
+
+    List<MemberPostcardFromResponse> getPostcardsFromMember(Long memberId);
+
+    List<MemberPostcardToResponse> getPostcardsToMember(Long memberId);
+
+    void useMemberPostcard(Long memberId, PostcardPayType type);
+
+    void updatePostcardStatus(Long postcardId, PostcardStatusUpdateRequest request);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/PostcardFromResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/PostcardFromResponse.java
@@ -1,0 +1,38 @@
+package com.bookbla.americano.domain.postcard.service.dto.response;
+
+import com.bookbla.americano.domain.member.enums.Gender;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class PostcardFromResponse {
+    // Member 정보
+    private long memberId;
+
+    private String memberName;
+
+    private LocalDate memberBirthDate;
+
+    private Gender memberGender;
+
+    private String memberSchoolName;
+
+    private String memberProfileImageUrl;
+
+    private String memberOpenKakaoRoomUrl;
+
+    // 엽서 정보
+    private PostcardStatus postcardStatus;
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/PostcardToResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/PostcardToResponse.java
@@ -1,0 +1,66 @@
+package com.bookbla.americano.domain.postcard.service.dto.response;
+
+import com.bookbla.americano.domain.member.enums.ContactType;
+import com.bookbla.americano.domain.member.enums.DateCostType;
+import com.bookbla.americano.domain.member.enums.DateStyleType;
+import com.bookbla.americano.domain.member.enums.DrinkType;
+import com.bookbla.americano.domain.member.enums.Gender;
+import com.bookbla.americano.domain.member.enums.JustFriendType;
+import com.bookbla.americano.domain.member.enums.Mbti;
+import com.bookbla.americano.domain.member.enums.SmokeType;
+import com.bookbla.americano.domain.quiz.enums.CorrectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+// 받은 엽서
+public class PostcardToResponse {
+
+    private long postcardId;
+
+    // Member 정보
+    private long memberId;
+
+    private String memberName;
+
+    private LocalDate memberBirthDate;
+
+    private Gender memberGender;
+
+    private String memberSchoolName;
+
+    private String memberProfileImageUrl;
+
+    private DrinkType drinkType;
+
+    private SmokeType smokeType;
+
+    private ContactType contactType;
+
+    private DateStyleType dateStyleType;
+
+    private DateCostType dateCostType;
+
+    private Mbti mbti;
+
+    private JustFriendType justFriendType;
+
+    // 책 제목
+    private String bookTitle;
+
+    // 독서 퀴즈 답
+    private CorrectStatus correctStatus;
+
+    // 개인 질문 답
+    private String memberReplyContent;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -206,12 +206,14 @@ public class PostcardServiceImpl implements PostcardService {
                     nowScore++;
             }
         }
+        if (!nowBookTitles.isEmpty()) {
+            nowResponse.setBookTitles(nowBookTitles);
+            nowResponse.setCorrectStatuses(nowCorrectStatuses);
+            nowResponse.setQuizScore(nowScore);
 
-        nowResponse.setBookTitles(nowBookTitles);
-        nowResponse.setCorrectStatuses(nowCorrectStatuses);
-        nowResponse.setQuizScore(nowScore);
-        // 리스트에 추가
-        memberPostcardToResponseList.add(nowResponse);
+            // 리스트에 추가
+            memberPostcardToResponseList.add(nowResponse);
+        }
         return memberPostcardToResponseList;
     }
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -2,17 +2,23 @@ package com.bookbla.americano.domain.postcard.service.impl;
 
 
 import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.exception.MemberAuthExceptionType;
 import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberPostcardRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPostcard;
+import com.bookbla.americano.domain.member.service.MemberBookService;
 import com.bookbla.americano.domain.memberask.exception.MemberAskExceptionType;
 import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
 import com.bookbla.americano.domain.memberask.repository.MemberReplyRepository;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
+import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
+import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
 import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
@@ -21,6 +27,8 @@ import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
 import com.bookbla.americano.domain.postcard.repository.entity.PostcardType;
 import com.bookbla.americano.domain.postcard.service.PostcardService;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
 import com.bookbla.americano.domain.quiz.enums.CorrectStatus;
@@ -33,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,6 +58,7 @@ public class PostcardServiceImpl implements PostcardService {
     private final MemberRepository memberRepository;
     private final PostcardTypeRepository postcardTypeRepository;
     private final MemberPostcardRepository memberPostcardRepository;
+    private final MemberBookService memberBookService;
 
     @Override
     public SendPostcardResponse send(Long memberId, SendPostcardRequest sendPostcardRequest) {
@@ -67,7 +77,7 @@ public class PostcardServiceImpl implements PostcardService {
         MemberPostcard memberPostcard = memberPostcardRepository.findMemberPostcardByMemberId(memberId)
                 .orElseThrow(() -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
 
-        if (memberPostcard.getFreePostcardCount() + memberPostcard.getPayPostcardCount()  == 0) {
+        if (memberPostcard.getFreePostcardCount() + memberPostcard.getPayPostcardCount() == 0) {
             return SendPostcardResponse.builder().isSendSuccess(false).build();
         }
 
@@ -121,4 +131,101 @@ public class PostcardServiceImpl implements PostcardService {
         return PostcardTypeResponse.of(postcardTypeList);
     }
 
+    @Override // 보낸 엽서
+    public List<MemberPostcardFromResponse> getPostcardsFromMember(Long memberId) {
+        List<PostcardFromResponse> postcardFromResponseList = postcardRepository.getPostcardsFromMember(memberId);
+        List<MemberPostcardFromResponse> memberPostcardFromResponseList = new ArrayList<>();
+
+        for (PostcardFromResponse i : postcardFromResponseList) {
+            MemberPostcardFromResponse nowResponse;
+            MemberBookReadResponses memberBookList = memberBookService.readMemberBooks(i.getMemberId());
+            List<String> nowBookImageUrls = new ArrayList<>();
+            nowResponse = new MemberPostcardFromResponse(i.getMemberId(), i.getMemberName(), getAge(i.getMemberBirthDate()),
+                    i.getMemberGender(), i.getMemberSchoolName(), i.getMemberProfileImageUrl(),
+                    i.getMemberOpenKakaoRoomUrl(), i.getPostcardStatus());
+            for (MemberBookReadResponses.MemberBookReadResponse j : memberBookList.getMemberBookReadResponses()) {
+                if (j.isRepresentative()) {
+                    nowResponse.setRepresentativeBookTitle(j.getTitle());
+                    nowResponse.setRepresentativeBookAuthor(j.getAuthors());
+                    nowBookImageUrls.add(0, j.getThumbnail());
+                } else {
+                    nowBookImageUrls.add(j.getThumbnail());
+                }
+            }
+            nowResponse.setBookImageUrls(nowBookImageUrls);
+            memberPostcardFromResponseList.add(nowResponse);
+        }
+
+        return memberPostcardFromResponseList;
+    }
+
+    private int getAge(LocalDate birthDay) {
+        return LocalDate.now().getYear() - birthDay.getYear();
+    }
+
+    @Override // 받은 엽서
+    public List<MemberPostcardToResponse> getPostcardsToMember(Long memberId) {
+        List<PostcardToResponse> postcardToResponseList = postcardRepository.getPostcardsToMember(memberId);
+        List<MemberPostcardToResponse> memberPostcardToResponseList = new ArrayList<>();
+        long now = -1;
+        MemberPostcardToResponse nowResponse = new MemberPostcardToResponse();
+        List<String> nowBookTitles = new ArrayList<>();
+        List<CorrectStatus> nowCorrectStatuses = new ArrayList<>();
+        int nowScore = 0;
+        for (PostcardToResponse i : postcardToResponseList) {
+            if (i.getMemberId() != now) {
+                if (now != -1) {
+                    nowResponse.setBookTitles(nowBookTitles);
+                    nowResponse.setCorrectStatuses(nowCorrectStatuses);
+                    nowResponse.setQuizScore(nowScore);
+                    // 리스트에 추가
+                    memberPostcardToResponseList.add(nowResponse);
+                }
+                // 초기화
+                now = i.getMemberId();
+                int age = getAge(i.getMemberBirthDate());
+                nowResponse = new MemberPostcardToResponse(i.getPostcardId(), i.getMemberId(), i.getMemberName(),
+                        i.getMemberProfileImageUrl(), age, i.getMemberGender(), i.getDrinkType(), i.getSmokeType(),
+                        i.getContactType(), i.getDateStyleType(), i.getDateCostType(), i.getMbti(), i.getJustFriendType(),
+                        i.getMemberSchoolName(), i.getMemberReplyContent());
+                nowBookTitles = new ArrayList<>();
+                nowCorrectStatuses = new ArrayList<>();
+                nowScore = 0;
+
+                // 책 퀴즈 정답 여부 저장
+                nowBookTitles.add(i.getBookTitle());
+                nowCorrectStatuses.add(i.getCorrectStatus());
+                if (i.getCorrectStatus().equals(CorrectStatus.CORRECT))
+                    nowScore++;
+            } else {
+                // 책 퀴즈 정답 여부 저장
+                nowBookTitles.add(i.getBookTitle());
+                nowCorrectStatuses.add(i.getCorrectStatus());
+                if (i.getCorrectStatus().equals(CorrectStatus.CORRECT))
+                    nowScore++;
+            }
+        }
+
+        nowResponse.setBookTitles(nowBookTitles);
+        nowResponse.setCorrectStatuses(nowCorrectStatuses);
+        nowResponse.setQuizScore(nowScore);
+        // 리스트에 추가
+        memberPostcardToResponseList.add(nowResponse);
+        return memberPostcardToResponseList;
+    }
+
+    @Override
+    public void useMemberPostcard(Long memberId, PostcardPayType type) {
+        if (type == PostcardPayType.FREE)
+            postcardRepository.useMemberFreePostcard(memberId);
+        else if (type == PostcardPayType.PAY)
+            postcardRepository.useMemberPayPostcard(memberId);
+        else
+            throw new BaseException(PostcardExceptionType.INVALID_TYPE);
+    }
+
+    @Override
+    public void updatePostcardStatus(Long postcardId, PostcardStatusUpdateRequest request) {
+        postcardRepository.updatePostcardStatus(request.getStatus(), postcardId);
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -42,6 +42,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -160,7 +161,7 @@ public class PostcardServiceImpl implements PostcardService {
     }
 
     private int getAge(LocalDate birthDay) {
-        return LocalDate.now().getYear() - birthDay.getYear();
+        return Period.between(birthDay, LocalDate.now()).getYears();
     }
 
     @Override // 받은 엽서
@@ -220,8 +221,6 @@ public class PostcardServiceImpl implements PostcardService {
             postcardRepository.useMemberFreePostcard(memberId);
         else if (type == PostcardPayType.PAY)
             postcardRepository.useMemberPayPostcard(memberId);
-        else
-            throw new BaseException(PostcardExceptionType.INVALID_TYPE);
     }
 
     @Override


### PR DESCRIPTION
## 📄 Summary

> 🏠**Home** 
> - 본인 외 다른 사용자 전체의 list를 보내주는 api 추가(members/all-other-members)
>
> 🧑‍🤝‍🧑**Matching**
> - 보낸 엽서/받은 엽서 조회 API 추가

## 🙋🏻 More
>🧑‍🤝‍🧑**Matching**(detail)
>- 받은 엽서(postcard/to) - GET
    - 사용자 정보 : 사용자 이름, 프로필 사진, 나이, 성별, 스타일, 학교
    - 퀴즈 답 정보 : 퀴즈 스코어, 책 제목(리스트), 독서 퀴즈 답(리스트), 개인 질문 답
    - 책 제목과 독서 퀴즈 답의 같은 index는 같은 책
>- 보낸 엽서(postcard/from) - GET
    - 사용자 정보 : 사용자 이름, 나이, 성별, 학교, 프로필 이미지, 카카오톡 오픈채팅 URL
    - 책 정보 : 대표 책(제목 / 작가), 모든 등록 책 이미지 url
    - 책 이미지의 0번째 index는 대표 책 이미지
>- 엽서 타입 별 개수 확인(postcard)  - GET
    - 무료 postcard 수, 유료 postcard 수
>- 엽서 사용(postcard/{payType}) - PATCH
    - payType : FREE / PAY
>- 엽서 상태 업데이트(status/{postcardId}) - POST
    - PostcardStatusUpdateRequest : status(PostcardStatus)
>
> **+) 줄맞춤 및 Class 이름, import 정리**