### PR TITLE
fix: 에러 로깅 형식 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/base/log/discord/DiscordMessage.java
+++ b/src/main/java/com/bookbla/americano/base/log/discord/DiscordMessage.java
@@ -22,14 +22,14 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 @Component
 public class DiscordMessage {
 
-    private static final int MAX_MESSAGE_LENGTH = 2_000;
-
     private static final String CRLF = "\n";
     private static final String EXTRACTION_ERROR_MESSAGE = "메시지 추출중 예외가 발생했습니다.\nmessage : %s";
     private static final String EXCEPTION_MESSAGE_FORMAT = "_%s_ %s.%s:%d - %s";
-    private static final String MESSAGE_FORMAT = "*[요청한 멤버 id]*\n%s\n\n" +
-            "*[REQUEST TIME]*\n%s\n\n" +
-            "*[ERROR LOG]*\n%s\n*%s* %s\n\n%s";
+    private static final String MESSAGE_FORMAT = "\n\n**[요청한 멤버 id]**\n%s\n\n" +
+            "**[요청 시간]**\n%s\n\n" +
+            "**[에러 로그]**\n%s\n[%s] %s\n\n" +
+            "*[Header]*\n%s\n\n" +
+            "*[Body]*\n%s\n\n";
 
     private final JwtProvider jwtProvider;
 

--- a/src/main/java/com/bookbla/americano/base/log/discord/ExceptionAppender.java
+++ b/src/main/java/com/bookbla/americano/base/log/discord/ExceptionAppender.java
@@ -3,7 +3,6 @@ package com.bookbla.americano.base.log.discord;
 import com.bookbla.americano.base.log.LogLevel;
 import com.bookbla.americano.base.log.RequestStorage;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 @Aspect
-@Slf4j
 public class ExceptionAppender {
 
     private final RequestStorage requestStorage;


### PR DESCRIPTION
## 📄 Summary

> 디스코드 상으로 전송되는 에러 메시지 형식을 조금 다듬었습니다

## 🙋🏻 More

>

전

<img width="744" alt="image" src="https://github.com/BookBLA/americano/assets/73161212/af402933-64d4-4601-933e-762e016aa226">


후

<img width="759" alt="image" src="https://github.com/BookBLA/americano/assets/73161212/01a159c4-113a-4caf-a96a-8967af1f16a3">
