### PR TITLE
feat: 엽서 전송 확인 API 구현 & 유료 엽서 대응 가능하도록 변경

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPostcard.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPostcard.java
@@ -1,6 +1,9 @@
 package com.bookbla.americano.domain.member.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseUpdateEntity;
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,8 +41,32 @@ public class MemberPostcard extends BaseUpdateEntity {
     @Builder.Default
     private int freePostcardCount = 1;
 
-    public MemberPostcard updateFreePostcardCount(int freePostcardCount) {
-        this.freePostcardCount = freePostcardCount;
-        return this;
+    public void use(PostcardPayType payType) {
+        validate(payType);
+        if (payType == PostcardPayType.FREE) {
+            freePostcardCount -= 1;
+        } else {
+            payPostcardCount -= 1;
+        }
+    }
+
+    public void validate(PostcardPayType payType) {
+        if (payType == PostcardPayType.FREE) {
+            validateFreePostcardCount();
+        } else {
+            validatePayPostcardCount();
+        }
+    }
+
+    private void validateFreePostcardCount() {
+        if (freePostcardCount <= 0) {
+            throw new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID);
+        }
+    }
+
+    private void validatePayPostcardCount() {
+        if (freePostcardCount <= 0) {
+            throw new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID);
+        }
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPostcard.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPostcard.java
@@ -65,7 +65,7 @@ public class MemberPostcard extends BaseUpdateEntity {
     }
 
     private void validatePayPostcardCount() {
-        if (freePostcardCount <= 0) {
+        if (payPostcardCount <= 0) {
             throw new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID);
         }
     }

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -59,13 +59,7 @@ public class PostcardController {
     @Operation(summary = "엽서 사용", description = "{payType}에 따라 무료 엽서 또는 유료 엽서 1개 사용. payType : FREE / PAY")
     @PatchMapping("/{payType}")
     public void usePostcard(@Parameter(hidden = true) @User LoginUser loginUser, @PathVariable String payType) {
-        try{
-            PostcardPayType postcardPayType = PostcardPayType.valueOf(payType.toUpperCase());
-            postcardService.useMemberPostcard(loginUser.getMemberId(), postcardPayType);
-        } catch (IllegalArgumentException e){
-            throw new BaseException(PostcardExceptionType.INVALID_PAY_TYPE);
-        }
-
+        postcardService.useMemberPostcard(loginUser.getMemberId(), payType);
     }
 
     @Operation(summary = "Postcard 상태 업데이트", description = "{postcardId}를 가진 엽서의 상태 업데이트. Body의 status 값으로 해당 엽서의 상태(PostcardStatus)를 변경함.")

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -5,9 +5,11 @@ import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.member.service.MemberPostcardService;
 import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
+import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardSendValidationRequest;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
 import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
 import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
 import com.bookbla.americano.domain.postcard.service.PostcardService;
@@ -80,6 +82,15 @@ public class PostcardController {
         Long memberId = loginUser.getMemberId();
         SendPostcardResponse sendSearchResponses = postcardService.send(memberId, sendPostcardRequest);
         return ResponseEntity.ok(sendSearchResponses);
+    }
+
+    @PostMapping("/send/validation")
+    public ResponseEntity<PostcardSendValidateResponse> sendPostcard(
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody PostcardSendValidationRequest request
+    ) {
+        PostcardSendValidateResponse response = postcardService.validateSendPostcard(loginUser.getMemberId(), request.getTargetMemberId());
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/type-list")

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/request/PostcardSendValidationRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/request/PostcardSendValidationRequest.java
@@ -1,0 +1,15 @@
+package com.bookbla.americano.domain.postcard.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class PostcardSendValidationRequest {
+
+    private Long targetMemberId;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardSendValidateResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardSendValidateResponse.java
@@ -1,10 +1,8 @@
 package com.bookbla.americano.domain.postcard.controller.dto.response;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Getter
 public class PostcardSendValidateResponse {
 
     private final boolean isRefused;
@@ -13,4 +11,7 @@ public class PostcardSendValidateResponse {
         return new PostcardSendValidateResponse(isRefused);
     }
 
+    public boolean getIsRefused() {
+        return isRefused;
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardSendValidateResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardSendValidateResponse.java
@@ -1,0 +1,16 @@
+package com.bookbla.americano.domain.postcard.controller.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class PostcardSendValidateResponse {
+
+    private final boolean isRefused;
+
+    public static PostcardSendValidateResponse from(boolean isRefused) {
+        return new PostcardSendValidateResponse(isRefused);
+    }
+
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardPayType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardPayType.java
@@ -1,5 +1,17 @@
 package com.bookbla.americano.domain.postcard.enums;
 
+import java.util.Arrays;
+
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
+
 public enum PostcardPayType {
-    FREE, PAY
+    FREE, PAY;
+
+    public static PostcardPayType from(String type) {
+        return Arrays.stream(values())
+                .filter(it -> it.name().equalsIgnoreCase(type))
+                .findAny()
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_PAY_TYPE));
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/enums/PostcardStatus.java
@@ -1,5 +1,10 @@
 package com.bookbla.americano.domain.postcard.enums;
 
 public enum PostcardStatus {
-    PENDING, ACCEPT, REFUSED, EXPIRED, ALL_WRONG
+
+    PENDING, ACCEPT, REFUSED, ALL_WRONG;
+
+    public boolean isRefused() {
+        return this == REFUSED;
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
@@ -12,6 +12,10 @@ public enum PostcardExceptionType implements ExceptionType {
 
     POSTCARD_TYPE_NOT_VALID(HttpStatus.NOT_FOUND, "postcard_001", "유효하지 않은 엽서 타입입니다."),
     INVALID_PAY_TYPE(HttpStatus.BAD_REQUEST, "postcard_002", "유효하지 않은 엽서 가격 유형입니다."),
+
+    PENDING_POSTCARD_EXISTS(HttpStatus.BAD_REQUEST, "postcard-003", "대기중인 엽서가 존재합니다."),
+    ACCEPTED_POSTCARD_EXISTS(HttpStatus.BAD_REQUEST, "postcard-004", "매칭된 엽서가 존재합니다."),
+    ALL_WRONG_POSTCARD_EXISTS(HttpStatus.BAD_REQUEST, "postcard-005", "독서 퀴즈를 모두 틀린 엽서가 존재합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardRepository.java
@@ -1,5 +1,7 @@
 package com.bookbla.americano.domain.postcard.repository;
 
+import java.util.List;
+
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.repository.custom.PostcardRepositoryCustom;
 import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
@@ -9,6 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostcardRepository extends JpaRepository<Postcard, Long>, PostcardRepositoryCustom {
+
     boolean existsBySendMemberIdAndReceiveMemberIdAndPostcardStatus(Long sendMemberId, Long receiveMemberId, PostcardStatus status);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -22,4 +25,6 @@ public interface PostcardRepository extends JpaRepository<Postcard, Long>, Postc
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Postcard p set p.postcardStatus = :status where p.id = :postcardId")
     void updatePostcardStatus(@Param("status") PostcardStatus status, @Param("postcardId") Long postcardId);
+
+    List<Postcard> findBySendMemberIdAndReceiveMemberId(@Param("sendMemberId") Long sendMemberId, @Param("receiveMemberId") Long receiveMemberId);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardTypeRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardTypeRepository.java
@@ -1,7 +1,14 @@
 package com.bookbla.americano.domain.postcard.repository;
 
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
 import com.bookbla.americano.domain.postcard.repository.entity.PostcardType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostcardTypeRepository extends JpaRepository<PostcardType, Long> {
+
+    default PostcardType getById(Long postCardTypeId) {
+        return findById(postCardTypeId)
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID));
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardTypeRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/PostcardTypeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostcardTypeRepository extends JpaRepository<PostcardType, Long> {
 
-    default PostcardType getById(Long postCardTypeId) {
+    default PostcardType getByIdOrThrow(Long postCardTypeId) {
         return findById(postCardTypeId)
                 .orElseThrow(() -> new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID));
     }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/entity/Postcard.java
@@ -1,9 +1,11 @@
 package com.bookbla.americano.domain.postcard.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseInsertEntity;
+import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +22,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+
+import static com.bookbla.americano.domain.postcard.enums.PostcardStatus.PENDING;
+import static com.bookbla.americano.domain.postcard.enums.PostcardStatus.ACCEPT;
+import static com.bookbla.americano.domain.postcard.enums.PostcardStatus.ALL_WRONG;
 
 @Entity
 @Getter
@@ -53,4 +59,19 @@ public class Postcard extends BaseInsertEntity {
     @Enumerated(EnumType.STRING)
     private PostcardStatus postcardStatus;
 
+    public void validateSendPostcard() {
+        if (postcardStatus == PENDING) {
+            throw new BaseException(PostcardExceptionType.PENDING_POSTCARD_EXISTS);
+        }
+        if (postcardStatus == ACCEPT) {
+            throw new BaseException(PostcardExceptionType.ACCEPTED_POSTCARD_EXISTS);
+        }
+        if (postcardStatus == ALL_WRONG) {
+            throw new BaseException(PostcardExceptionType.ALL_WRONG_POSTCARD_EXISTS);
+        }
+    }
+
+    public boolean isRefused() {
+        return postcardStatus.isRefused();
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -4,7 +4,6 @@ import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStat
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
-import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
@@ -20,7 +19,7 @@ public interface PostcardService {
 
     List<MemberPostcardToResponse> getPostcardsToMember(Long memberId);
 
-    void useMemberPostcard(Long memberId, PostcardPayType type);
+    void useMemberPostcard(Long memberId, String payType);
 
     void updatePostcardStatus(Long postcardId, PostcardStatusUpdateRequest request);
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.postcard.service;
 import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
 import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
@@ -22,4 +23,6 @@ public interface PostcardService {
     void useMemberPostcard(Long memberId, PostcardPayType type);
 
     void updatePostcardStatus(Long postcardId, PostcardStatusUpdateRequest request);
+
+    PostcardSendValidateResponse validateSendPostcard(Long memberId, Long targetMemberId);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
@@ -21,9 +21,6 @@ public class SendPostcardRequest {
     @NotNull(message = "postcardTypeId가 입력되지 않았습니다.")
     private Long postcardTypeId;
 
-    @NotNull(message = "imageUrl이 입력되지 않았습니다.")
-    private String imageUrl;
-
     @NotBlank(message = "엽서를 보낼 상대방의 식별자가 입력되지 않았습니다")
     private Long receiveMemberId;
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
@@ -1,15 +1,14 @@
 package com.bookbla.americano.domain.postcard.service.dto.request;
 
-import com.bookbla.americano.domain.quiz.repository.entity.QuizReply;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.List;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -25,7 +24,9 @@ public class SendPostcardRequest {
     @NotNull(message = "imageUrl이 입력되지 않았습니다.")
     private String imageUrl;
 
-    @NotNull(message = "memberAskId가 입력되지 않았습니다.")
+    @NotBlank(message = "엽서를 보낼 상대방의 식별자가 입력되지 않았습니다")
+    private Long receiveMemberId;
+
     private Long memberAskId;
 
     @NotNull(message = "memberReply가 입력되지 않았습니다.")
@@ -36,6 +37,7 @@ public class SendPostcardRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class QuizAnswer {
+
         private Long quizId;
         private String quizAnswer;
     }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.postcard.service.dto.request;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -29,6 +30,9 @@ public class SendPostcardRequest {
     @NotNull(message = "memberReply가 입력되지 않았습니다.")
     @Size(max = 150)
     private String memberReply;
+
+    @Schema(description = "엽서의 유료/무료 타입", example = "Free/Pay")
+    private String postcardPayType;
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -84,9 +84,7 @@ public class PostcardServiceImpl implements PostcardService {
         List<QuizReply> correctReplies = new ArrayList<>();
         boolean isCorrect = false;
         for (SendPostcardRequest.QuizAnswer quizAnswer : request.getQuizAnswerList()) {
-            QuizQuestion quizQuestion = quizQuestionRepository.findById(quizAnswer.getQuizId())
-                    .orElseThrow(() -> new BaseException(QuizQuestionExceptionType.MEMBER_QUIZ_QUESTION_NOT_FOUND));
-
+            QuizQuestion quizQuestion = quizQuestionRepository.getByIdOrThrow(quizAnswer.getQuizId());
             CorrectStatus status = quizQuestion.solve(quizAnswer.getQuizAnswer());
 
             QuizReply quizReply = QuizReply.builder()
@@ -106,7 +104,7 @@ public class PostcardServiceImpl implements PostcardService {
 
         memberPostcard.use(payType);
 
-        PostcardType postCardType = postcardTypeRepository.getById(request.getPostcardTypeId());
+        PostcardType postCardType = postcardTypeRepository.getByIdOrThrow(request.getPostcardTypeId());
         Postcard postcard = Postcard.builder()
                 .sendMember(member)
                 .receiveMember(targetMember)

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -62,13 +62,16 @@ public class PostcardServiceImpl implements PostcardService {
     private final MemberBookService memberBookService;
 
     @Override
-    public SendPostcardResponse send(Long memberId, SendPostcardRequest sendPostcardRequest) {
-        MemberAsk memberAsk = memberAskRepository.findById(sendPostcardRequest.getMemberAskId())
+    public SendPostcardResponse send(Long memberId, SendPostcardRequest request) {
+        List<Postcard> sentPostcards = postcardRepository.findBySendMemberIdAndReceiveMemberId(memberId, request.getReceiveMemberId());
+        sentPostcards.forEach(Postcard::validateSendPostcard);
+
+        MemberAsk memberAsk = memberAskRepository.findById(request.getMemberAskId())
                 .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
 
         MemberReply memberReply = MemberReply.builder()
                 .memberAsk(memberAsk)
-                .content(sendPostcardRequest.getMemberReply())
+                .content(request.getMemberReply())
                 .build();
         memberReplyRepository.save(memberReply);
 
@@ -112,9 +115,8 @@ public class PostcardServiceImpl implements PostcardService {
                 .receiveMember(targetMember)
                 .postcardStatus(status)
                 .memberReply(memberReply)
-                .postcardType(postcardTypeRepository.findById(sendPostcardRequest.getPostcardTypeId())
-                        .orElseThrow(() -> new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID)))
-                .imageUrl(sendPostcardRequest.getImageUrl())
+                .postcardType(postcardTypeRepository.getById(request.getPostcardTypeId()))
+                .imageUrl(request.getImageUrl())
                 .build();
         postcardRepository.save(postcard);
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -110,13 +110,14 @@ public class PostcardServiceImpl implements PostcardService {
         PostcardStatus status = isCorrect ? PostcardStatus.PENDING : PostcardStatus.ALL_WRONG;
 
         memberPostcard.updateFreePostcardCount(memberPostcard.getFreePostcardCount() - 1);
+        PostcardType postCardType = postcardTypeRepository.getById(request.getPostcardTypeId());
         Postcard postcard = Postcard.builder()
                 .sendMember(member)
                 .receiveMember(targetMember)
                 .postcardStatus(status)
                 .memberReply(memberReply)
-                .postcardType(postcardTypeRepository.getById(request.getPostcardTypeId()))
-                .imageUrl(request.getImageUrl())
+                .postcardType(postCardType)
+                .imageUrl(postCardType.getImageUrl())
                 .build();
         postcardRepository.save(postcard);
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -87,7 +87,8 @@ public class PostcardServiceImpl implements PostcardService {
             QuizQuestion quizQuestion = quizQuestionRepository.findById(quizAnswer.getQuizId())
                     .orElseThrow(() -> new BaseException(QuizQuestionExceptionType.MEMBER_QUIZ_QUESTION_NOT_FOUND));
 
-            CorrectStatus status = quizQuestion.getFirstChoice().equals(quizAnswer.getQuizAnswer()) ? CorrectStatus.CORRECT : CorrectStatus.WRONG;
+            CorrectStatus status = quizQuestion.solve(quizAnswer.getQuizAnswer());
+
             QuizReply quizReply = QuizReply.builder()
                     .quizQuestion(quizQuestion)
                     .answer(quizAnswer.getQuizAnswer())

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -220,7 +220,8 @@ public class PostcardServiceImpl implements PostcardService {
     }
 
     @Override
-    public void useMemberPostcard(Long memberId, PostcardPayType type) {
+    public void useMemberPostcard(Long memberId, String payType) {
+        PostcardPayType type = PostcardPayType.from(payType);
         if (type == PostcardPayType.FREE)
             postcardRepository.useMemberFreePostcard(memberId);
         else if (type == PostcardPayType.PAY)

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizQuestionRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/QuizQuestionRepository.java
@@ -1,11 +1,18 @@
 package com.bookbla.americano.domain.quiz.repository;
 
+import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
+import com.bookbla.americano.domain.quiz.exception.QuizQuestionExceptionType;
 import com.bookbla.americano.domain.quiz.repository.entity.QuizQuestion;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long> {
+
+    default QuizQuestion getByIdOrThrow(Long quizQuestionId) {
+        return findById(quizQuestionId)
+                .orElseThrow(() -> new BaseException(QuizQuestionExceptionType.MEMBER_QUIZ_QUESTION_NOT_FOUND));
+    }
 
     Optional<QuizQuestion> findByMemberBook(MemberBook memberBook);
 

--- a/src/main/java/com/bookbla/americano/domain/quiz/repository/entity/QuizQuestion.java
+++ b/src/main/java/com/bookbla/americano/domain/quiz/repository/entity/QuizQuestion.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.quiz.repository.entity;
 import com.bookbla.americano.base.entity.BaseInsertEntity;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
 import com.bookbla.americano.domain.quiz.enums.AnswerChoice;
+import com.bookbla.americano.domain.quiz.enums.CorrectStatus;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -60,5 +61,10 @@ public class QuizQuestion extends BaseInsertEntity {
     public QuizQuestion updateSecondWrongAnswer(String secondWrongAnswer) {
         this.thirdChoice = secondWrongAnswer;
         return this;
+    }
+
+    public CorrectStatus solve(String answer) {
+        return answer.equals(firstChoice)
+                ? CorrectStatus.CORRECT : CorrectStatus.WRONG;
     }
 }

--- a/src/test/java/com/bookbla/americano/domain/postcard/repository/entity/PostcardTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/repository/entity/PostcardTest.java
@@ -1,0 +1,39 @@
+package com.bookbla.americano.domain.postcard.repository.entity;
+
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PostcardTest {
+
+    @EnumSource(mode = INCLUDE, names = {"PENDING", "ACCEPT", "ALL_WRONG"})
+    @ParameterizedTest(name = "엽서를_보낼_수_없다면_예외를_던진다")
+    void 엽서를_보낼_수_없다면_예외를_던진다(PostcardStatus status) {
+        // given
+        Postcard postcard = Postcard.builder().postcardStatus(status).build();
+
+        // when, then
+        assertThatThrownBy(postcard::validateSendPostcard)
+                .isInstanceOf(BaseException.class)
+                .hasMessageContaining(" 엽서가 존재합니다.");
+    }
+
+    @Test
+    void 엽서를_보낼_수_있는지_검증한다() {
+        // given
+        Postcard postcard = Postcard.builder().postcardStatus(PostcardStatus.REFUSED).build();
+
+        // when, then
+        assertDoesNotThrow(postcard::validateSendPostcard);
+    }
+}

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -7,6 +7,7 @@ import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSen
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
 import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -83,5 +84,11 @@ class PostcardServiceTest {
 
         // then
         assertThat(response.getIsRefused()).isTrue();
+    }
+
+    @AfterEach
+    void tearDown() {
+        postcardRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 }

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -1,0 +1,87 @@
+package com.bookbla.americano.domain.postcard.service;
+
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.member.repository.MemberRepository;
+import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.bookbla.americano.domain.postcard.enums.PostcardStatus.REFUSED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
+
+@SpringBootTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PostcardServiceTest {
+
+    @Autowired
+    private PostcardService postcardService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostcardRepository postcardRepository;
+
+    @EnumSource(mode = INCLUDE, names = {"PENDING", "ACCEPT", "ALL_WRONG"})
+    @ParameterizedTest(name = "엽서를_보낼_수_없다면_예외를_반환한다")
+    void 엽서를_보낼_수_없다면_예외를_반환한다(PostcardStatus postcardStatus) {
+        // given
+        Member sendMember = memberRepository.save(Member.builder().build());
+        Member reciveMember = memberRepository.save(Member.builder().build());
+
+        Postcard unSendablePostcard = postcardRepository.save(Postcard.builder()
+                .sendMember(sendMember)
+                .receiveMember(reciveMember)
+                .postcardStatus(postcardStatus)
+                .build());
+
+        // when, then
+        assertThatThrownBy(() -> postcardService.validateSendPostcard(sendMember.getId(), reciveMember.getId()))
+                .isInstanceOf(BaseException.class)
+                .hasMessageContaining(" 엽서가 존재합니다");
+    }
+
+    @Test
+    void 기존에_보낸_엽서가_존재하지_않는다면_엽서를_전송할_수_있다() {
+        // given
+        Member sendMember = memberRepository.save(Member.builder().build());
+        Member reciveMember = memberRepository.save(Member.builder().build());
+
+        // when
+        PostcardSendValidateResponse response = postcardService.validateSendPostcard(sendMember.getId(), reciveMember.getId());
+
+        // then
+        assertThat(response.isRefused()).isFalse();
+    }
+
+    @Test
+    void 기존에_보낸_엽서가_거절되었다면_엽서를_전송할_수_있다() {
+        // given
+        Member sendMember = memberRepository.save(Member.builder().build());
+        Member reciveMember = memberRepository.save(Member.builder().build());
+
+        Postcard refusedPostcard = postcardRepository.save(Postcard.builder()
+                .sendMember(sendMember)
+                .receiveMember(reciveMember)
+                .postcardStatus(REFUSED)
+                .build());
+
+        // when
+        PostcardSendValidateResponse response = postcardService.validateSendPostcard(sendMember.getId(), reciveMember.getId());
+
+        // then
+        assertThat(response.isRefused()).isTrue();
+    }
+}

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -63,7 +63,7 @@ class PostcardServiceTest {
         PostcardSendValidateResponse response = postcardService.validateSendPostcard(sendMember.getId(), reciveMember.getId());
 
         // then
-        assertThat(response.isRefused()).isFalse();
+        assertThat(response.getIsRefused()).isFalse();
     }
 
     @Test
@@ -82,6 +82,6 @@ class PostcardServiceTest {
         PostcardSendValidateResponse response = postcardService.validateSendPostcard(sendMember.getId(), reciveMember.getId());
 
         // then
-        assertThat(response.isRefused()).isTrue();
+        assertThat(response.getIsRefused()).isTrue();
     }
 }


### PR DESCRIPTION
## 📄 Summary

>

1. 엽서 보내기 전 검증용 API를 만들었습니다 
```[POST] /api/postcard/send/validation```

전송 불가능한 경우, 예외를 던져 GlobalExceptionHandler에서 잡아, 기본 응답의 isSuccess 값을 false로 반환하도록 하였슴다
-> 메시지로 이유 던져줍니다
전송 가능한 경우, isRefund (boolean)을 통해, 이전에 보냈으나 거절당한 엽서가 있는지를 확인하도록 하였슴다

2. 엽서 보내기 API를 조금 수정하였습니다
- 유료 추가 대비해서, postcardPayType을 보내도록 하였슴다
- 요청시 memberAskId를 보내야 하던 것을 없애고, 엽서를 보내려는 상대방의 memberId를 보내도록 변경하였슴다(이게 더 편하실 것 같아서...!)
- postCardTypeId를 보내고 있으니, 엽서 이미지 링크를 보낼 필요는 없을 것 같아 imageUrl을 안받도록 하였슴다
- 1번에서 사용하는, 전송 불가능한 경우인지 체크하는 로직을 같이 넣어놨어요

## 🙋🏻 More

> 2번 엽서 보내기 API 내역이 주현님께서 요번에 작업해주신 부분과 일부 겹치는 것 같습니다(유료엽서, 무료엽서 개수 차감 로직)
요렇게 올라가도 되는지 한 번 확인해주시면 감사하겠습니다..!