### PR TITLE
fix: 엽서 차감 로직 변경 & 프로필 검증 테이블 적용

### DIFF
--- a/src/main/java/com/bookbla/americano/base/utils/ConvertUtil.java
+++ b/src/main/java/com/bookbla/americano/base/utils/ConvertUtil.java
@@ -30,4 +30,5 @@ public class ConvertUtil {
                 .map(it -> it.getKey() + KEY_VALUE_DELIMITER + it.getValue())
                 .collect(Collectors.joining(ELEMENTS_DELIMITER));
     }
+
 }

--- a/src/main/java/com/bookbla/americano/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/controller/AdminController.java
@@ -3,13 +3,11 @@ package com.bookbla.americano.domain.admin.controller;
 import com.bookbla.americano.domain.admin.controller.dto.request.AdminMemberKakaoRoomStatusUpdateRequest;
 import com.bookbla.americano.domain.admin.controller.dto.request.AdminMemberProfileImageStatusUpdateRequest;
 import com.bookbla.americano.domain.admin.controller.dto.request.AdminMemberPushAlarmRequest;
-import com.bookbla.americano.domain.admin.controller.dto.request.AdminMemberStatusUpdateRequest;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberKakaoRoomResponses;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberProfileImageResponses;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberProfileStatusResponse;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberReadResponses;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberStudentIdResponses;
-import com.bookbla.americano.domain.admin.controller.dto.response.AdminPendingMemberResponses;
 import com.bookbla.americano.domain.admin.service.AdminMemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
@@ -40,38 +38,11 @@ public class AdminController {
         return ResponseEntity.ok(adminMemberReadResponses);
     }
 
-    @Operation(summary = "회원 승인 대기중인 목록 조회 API")
-    @GetMapping("/members/approval")
-    public ResponseEntity<AdminPendingMemberResponses> readPendingMembers(Pageable pageable) {
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
-        AdminPendingMemberResponses adminPendingMemberResponses = adminMemberService.readPendingMembers(pageRequest);
-        return ResponseEntity.ok(adminPendingMemberResponses);
-    }
-
-    @Operation(summary = "회원 상태 업데이트 API")
-    @PatchMapping("/members/{memberId}/profile/status")
-    public ResponseEntity<Void> updateMemberStatus(
-            @PathVariable Long memberId,
-            @RequestBody @Valid AdminMemberStatusUpdateRequest request
-    ) {
-        adminMemberService.updatePendingMemberStatus(request.toDto(memberId));
-        return ResponseEntity.ok().build();
-    }
-
     @Operation(summary = "회원 프로필의 상태 목록 조회 API")
     @GetMapping("/member/profile/status")
     public ResponseEntity<AdminMemberProfileStatusResponse> getMemberStatuses() {
         AdminMemberProfileStatusResponse adminMemberProfileStatusResponse = adminMemberService.readProfileStatuses();
         return ResponseEntity.ok(adminMemberProfileStatusResponse);
-    }
-
-    @Operation(summary = "광고 동의 회원 대상 푸시 알림 전송 API")
-    @PostMapping("/alarm")
-    public ResponseEntity<Void> pushAlarm(
-            @RequestBody @Valid AdminMemberPushAlarmRequest request
-    ) {
-        adminMemberService.sendPushAlarm(request.toDto());
-        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "탈퇴 회원 목록 조회 API")
@@ -82,6 +53,7 @@ public class AdminController {
         return ResponseEntity.ok(adminMemberReadResponses);
     }
 
+    @Operation(summary = "카카오톡 오픈 승인 채팅방 대기 회원 조회 API")
     @GetMapping("/members/pending/kakao")
     public ResponseEntity<AdminMemberKakaoRoomResponses> readKakaoOpenRoomUrlPendingMembers(Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
@@ -89,6 +61,7 @@ public class AdminController {
         return ResponseEntity.ok(adminMemberKakaoRoomResponses);
     }
 
+    @Operation(summary = "카카오톡 오픈 채팅방 상태 변경 API")
     @PatchMapping("/member-verifies/{memberVerifyId}/pending/kakao")
     public ResponseEntity<Void> updateKakaoRoomUrlPendingMemberStatus(
             @PathVariable Long memberVerifyId,
@@ -98,6 +71,7 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "프로필 이미지 승인 대기 회원 조회 API")
     @GetMapping("/members/pending/image")
     public ResponseEntity<AdminMemberProfileImageResponses> readProfileImagePendingMembers(Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
@@ -105,6 +79,7 @@ public class AdminController {
         return ResponseEntity.ok(adminMemberProfileImageResponses);
     }
 
+    @Operation(summary = "프로필 이미지 상태 변경 API")
     @PatchMapping("/member-verifies/{memberVerifyId}/pending/image")
     public ResponseEntity<Void> updateProfileImagePendingMemberStatus(
             @PathVariable Long memberVerifyId,
@@ -114,6 +89,7 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "학생증 승인 대기 회원 조회 API")
     @GetMapping("/members/pending/student-id/image")
     public ResponseEntity<AdminMemberStudentIdResponses> readStudentIdPendingMembers(Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
@@ -121,12 +97,22 @@ public class AdminController {
         return ResponseEntity.ok(adminMemberStudentIdResponses);
     }
 
-    @PatchMapping("/member-verifies/{memberVerifyId}/pending/studentId/image")
+    @Operation(summary = "학생증 이미지 상태 변경 API")
+    @PatchMapping("/member-verifies/{memberVerifyId}/pending/student-id/image")
     public ResponseEntity<Void> updateStudentIdPendingMemberStatus(
             @PathVariable Long memberVerifyId,
             @RequestBody @Valid AdminMemberProfileImageStatusUpdateRequest request
     ) {
         adminMemberService.updateMemberStudentIdStatus(request.toDto(memberVerifyId));
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "광고 동의 회원 대상 푸시 알림 전송 API")
+    @PostMapping("/alarm")
+    public ResponseEntity<Void> pushAlarm(
+            @RequestBody @Valid AdminMemberPushAlarmRequest request
+    ) {
+        adminMemberService.sendPushAlarm(request.toDto());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/controller/AdminController.java
@@ -72,7 +72,7 @@ public class AdminController {
     }
 
     @Operation(summary = "프로필 이미지 승인 대기 회원 조회 API")
-    @GetMapping("/members/pending/image")
+    @GetMapping("/members/pending/profile-image")
     public ResponseEntity<AdminMemberProfileImageResponses> readProfileImagePendingMembers(Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize());
         AdminMemberProfileImageResponses adminMemberProfileImageResponses = adminMemberService.readProfileImagePendingMembers(pageRequest);
@@ -80,7 +80,7 @@ public class AdminController {
     }
 
     @Operation(summary = "프로필 이미지 상태 변경 API")
-    @PatchMapping("/member-verifies/{memberVerifyId}/pending/image")
+    @PatchMapping("/member-verifies/{memberVerifyId}/pending/profile-image")
     public ResponseEntity<Void> updateProfileImagePendingMemberStatus(
             @PathVariable Long memberVerifyId,
             @RequestBody @Valid AdminMemberProfileImageStatusUpdateRequest request

--- a/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberKakaoRoomResponses.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberKakaoRoomResponses.java
@@ -28,6 +28,7 @@ public class AdminMemberKakaoRoomResponses {
     @Getter
     static class AdminMemberKakaoRoomResponse {
 
+        private final Long memberVerifyId;
         private final Long memberId;
         private final String name;
         private final String openKakaoRoomUrl;
@@ -35,6 +36,7 @@ public class AdminMemberKakaoRoomResponses {
         public static AdminMemberKakaoRoomResponse from(MemberVerify memberVerify) {
 
             return AdminMemberKakaoRoomResponse.builder()
+                    .memberVerifyId(memberVerify.getId())
                     .memberId(memberVerify.getMemberId())
                     .name(memberVerify.getDescription())
                     .openKakaoRoomUrl(memberVerify.getContents())

--- a/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberProfileImageResponses.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberProfileImageResponses.java
@@ -28,12 +28,14 @@ public class AdminMemberProfileImageResponses {
     @Getter
     static class AdminMemberProfileImageResponse {
 
+        private final Long memberVerifyId;
         private final Long memberId;
         private final String gender;
         private final String profileImageUrl;
 
         public static AdminMemberProfileImageResponse from(MemberVerify memberVerify) {
             return AdminMemberProfileImageResponse.builder()
+                    .memberVerifyId(memberVerify.getId())
                     .memberId(memberVerify.getMemberId())
                     .gender(memberVerify.getDescription())
                     .profileImageUrl(memberVerify.getContents())

--- a/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberStudentIdResponses.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberStudentIdResponses.java
@@ -36,8 +36,8 @@ public class AdminMemberStudentIdResponses {
         private final Long memberId;
         private final String name;
         private final String schoolName;
-        private final String major;
-        private final String studentNumber;
+        private final String birthDate;
+        private final String gender;
         private final String studentIdImageUrl;
 
         public static AdminMemberStudentIdResponse from(MemberVerify memberVerify) {
@@ -48,8 +48,8 @@ public class AdminMemberStudentIdResponses {
                     .memberId(memberVerify.getMemberId())
                     .name(descriptions.getOrDefault("name", DESCRIPTION_PARSING_FAIL))
                     .schoolName(descriptions.getOrDefault("schoolName", DESCRIPTION_PARSING_FAIL))
-                    .major(descriptions.getOrDefault("major", DESCRIPTION_PARSING_FAIL))
-                    .studentNumber(descriptions.getOrDefault("studentId", DESCRIPTION_PARSING_FAIL))
+                    .gender(descriptions.getOrDefault("gender", DESCRIPTION_PARSING_FAIL))
+                    .birthDate(descriptions.getOrDefault("birthDate", DESCRIPTION_PARSING_FAIL))
                     .studentIdImageUrl(memberVerify.getContents())
                     .build();
         }

--- a/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberStudentIdResponses.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/controller/dto/response/AdminMemberStudentIdResponses.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import static com.bookbla.americano.domain.member.repository.entity.MemberVerify.DESCRIPTION_PARSING_FAIL;
+
 @AllArgsConstructor
 @Getter
 public class AdminMemberStudentIdResponses {
@@ -30,22 +32,24 @@ public class AdminMemberStudentIdResponses {
     @Getter
     static class AdminMemberStudentIdResponse {
 
+        private final Long memberVerifyId;
         private final Long memberId;
         private final String name;
         private final String schoolName;
         private final String major;
-        private final String studentId;
+        private final String studentNumber;
         private final String studentIdImageUrl;
 
         public static AdminMemberStudentIdResponse from(MemberVerify memberVerify) {
             Map<String, String> descriptions = ConvertUtil.stringToMap(memberVerify.getDescription());
 
             return AdminMemberStudentIdResponse.builder()
+                    .memberVerifyId(memberVerify.getId())
                     .memberId(memberVerify.getMemberId())
-                    .name(descriptions.get("name"))
-                    .schoolName(descriptions.get("schoolName"))
-                    .major(descriptions.get("major"))
-                    .studentId("studetId")
+                    .name(descriptions.getOrDefault("name", DESCRIPTION_PARSING_FAIL))
+                    .schoolName(descriptions.getOrDefault("schoolName", DESCRIPTION_PARSING_FAIL))
+                    .major(descriptions.getOrDefault("major", DESCRIPTION_PARSING_FAIL))
+                    .studentNumber(descriptions.getOrDefault("studentId", DESCRIPTION_PARSING_FAIL))
                     .studentIdImageUrl(memberVerify.getContents())
                     .build();
         }

--- a/src/main/java/com/bookbla/americano/domain/admin/service/AdminMemberService.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/service/AdminMemberService.java
@@ -15,6 +15,7 @@ import com.bookbla.americano.domain.admin.service.dto.AlarmDto;
 import com.bookbla.americano.domain.admin.service.dto.StatusUpdateDto;
 import com.bookbla.americano.domain.alarm.service.AlarmClient;
 import com.bookbla.americano.domain.alarm.service.AlarmService;
+import com.bookbla.americano.domain.member.enums.Gender;
 import com.bookbla.americano.domain.member.enums.MemberStatus;
 import com.bookbla.americano.domain.member.enums.OpenKakaoRoomStatus;
 import com.bookbla.americano.domain.member.enums.ProfileImageStatus;
@@ -158,6 +159,7 @@ public class AdminMemberService {
         if (status.isDone()) {
             Map<String, String> descriptions = ConvertUtil.stringToMap(memberVerify.getDescription());
             memberProfile.updateStudentIdImageUrl(memberVerify.getContents())
+                    .updateGender(Gender.from(descriptions.getOrDefault("gender", DESCRIPTION_PARSING_FAIL)))
                     .updateName(descriptions.getOrDefault("name", DESCRIPTION_PARSING_FAIL))
                     .updateSchoolName(descriptions.getOrDefault("schoolName", DESCRIPTION_PARSING_FAIL))
                     .updateBirthDate(LocalDate.parse(descriptions.getOrDefault("birthDate", DESCRIPTION_PARSING_FAIL)));

--- a/src/main/java/com/bookbla/americano/domain/admin/service/AdminMemberService.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/service/AdminMemberService.java
@@ -1,16 +1,17 @@
 package com.bookbla.americano.domain.admin.service;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.bookbla.americano.base.utils.ConvertUtil;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberKakaoRoomResponses;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberProfileImageResponses;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberProfileStatusResponse;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberReadResponses;
 import com.bookbla.americano.domain.admin.controller.dto.response.AdminMemberStudentIdResponses;
-import com.bookbla.americano.domain.admin.controller.dto.response.AdminPendingMemberResponses;
 import com.bookbla.americano.domain.admin.service.dto.AlarmDto;
-import com.bookbla.americano.domain.admin.service.dto.MemberStatusUpdateDto;
 import com.bookbla.americano.domain.admin.service.dto.StatusUpdateDto;
 import com.bookbla.americano.domain.alarm.service.AlarmClient;
 import com.bookbla.americano.domain.alarm.service.AlarmService;
@@ -33,6 +34,7 @@ import static com.bookbla.americano.domain.member.enums.MemberVerifyStatus.PENDI
 import static com.bookbla.americano.domain.member.enums.MemberVerifyType.OPEN_KAKAO_ROOM_URL;
 import static com.bookbla.americano.domain.member.enums.MemberVerifyType.PROFILE_IMAGE;
 import static com.bookbla.americano.domain.member.enums.MemberVerifyType.STUDENT_ID;
+import static com.bookbla.americano.domain.member.repository.entity.MemberVerify.DESCRIPTION_PARSING_FAIL;
 
 @RequiredArgsConstructor
 @Transactional
@@ -52,31 +54,12 @@ public class AdminMemberService {
         return AdminMemberReadResponses.from(count, members);
     }
 
-    @Transactional(readOnly = true)
-    public AdminPendingMemberResponses readPendingMembers(Pageable pageable) {
-        long count = memberRepository.countByMemberStatus(MemberStatus.APPROVAL);
-        Page<Member> pendingMemberPaging = memberRepository.findByMemberStatus(MemberStatus.APPROVAL, pageable);
-        List<Member> members = pendingMemberPaging.getContent();
-        return AdminPendingMemberResponses.from(count, members);
-    }
-
     public AdminMemberProfileStatusResponse readProfileStatuses() {
         return AdminMemberProfileStatusResponse.of(
                 ProfileImageStatus.getValues(),
                 OpenKakaoRoomStatus.getValues(),
                 StudentIdImageStatus.getValues()
         );
-    }
-
-    public void updatePendingMemberStatus(MemberStatusUpdateDto dto) {
-        Member member = memberRepository.getByIdOrThrow(dto.getMemberId());
-        MemberProfile memberProfile = member.getMemberProfile();
-
-        memberProfile.updateStudentIdImageStatus(dto.getStudentIdImageStatus())
-                .updateProfileImageStatus(dto.getProfileImageStatus())
-                .updateOpenKakaoRoomStatus(dto.getOpenKakaoRoomStatus());
-
-        member.updateMemberStatus();
     }
 
     public void sendPushAlarm(AlarmDto alarmDto) {
@@ -122,7 +105,9 @@ public class AdminMemberService {
             memberVerify.fail(dto.getReason());
         }
 
-        member.updateMemberStatus();
+        if (member.getMemberStatus() == MemberStatus.APPROVAL) {
+            member.updateMemberStatus();
+        }
     }
 
     @Transactional(readOnly = true)
@@ -149,7 +134,9 @@ public class AdminMemberService {
             memberVerify.fail(dto.getReason());
         }
 
-        member.updateMemberStatus();
+        if (member.getMemberStatus() == MemberStatus.APPROVAL) {
+            member.updateMemberStatus();
+        }
     }
 
     @Transactional(readOnly = true)
@@ -169,9 +156,13 @@ public class AdminMemberService {
         memberProfile.updateStudentIdImageStatus(status);
 
         if (status.isDone()) {
-            memberVerify.success();
+            Map<String, String> descriptions = ConvertUtil.stringToMap(memberVerify.getDescription());
+            memberProfile.updateStudentIdImageUrl(memberVerify.getContents())
+                    .updateName(descriptions.getOrDefault("name", DESCRIPTION_PARSING_FAIL))
+                    .updateSchoolName(descriptions.getOrDefault("schoolName", DESCRIPTION_PARSING_FAIL))
+                    .updateBirthDate(LocalDate.parse(descriptions.getOrDefault("birthDate", DESCRIPTION_PARSING_FAIL)));
 
-            memberProfile.updateStudentIdImageUrl(memberVerify.getContents());
+            memberVerify.success();
         } else {
             memberVerify.fail(dto.getReason());
         }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
@@ -3,6 +3,8 @@ package com.bookbla.americano.domain.member.controller;
 import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileCreateRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileImageUpdateRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileOpenKakaoRoomUrlUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileStatusUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
@@ -22,13 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 
 @RestController
-@RequestMapping("/member-profiles")
+@RequestMapping
 @RequiredArgsConstructor
 public class MemberProfileController {
 
     private final MemberProfileService memberProfileService;
 
-    @PostMapping
+    @PostMapping("/member-profiles")
     public ResponseEntity<MemberProfileResponse> createMemberProfile(
         @Parameter(hidden = true) @User LoginUser loginUser,
         @RequestBody @Valid MemberProfileCreateRequest memberProfileCreateRequest) {
@@ -38,7 +40,7 @@ public class MemberProfileController {
         return ResponseEntity.ok(memberProfileResponse);
     }
 
-    @GetMapping
+    @GetMapping("/member-profiles")
     public ResponseEntity<MemberProfileResponse> readMemberProfile(
         @Parameter(hidden = true) @User LoginUser loginUser) {
         MemberProfileResponse memberProfileResponse = memberProfileService.readMemberProfile(
@@ -46,7 +48,7 @@ public class MemberProfileController {
         return ResponseEntity.ok(memberProfileResponse);
     }
 
-    @PutMapping
+    @PutMapping("/member-profiles")
     public ResponseEntity<MemberProfileResponse> updateMemberProfile(
         @Parameter(hidden = true) @User LoginUser loginUser,
         @RequestBody @Valid MemberProfileUpdateRequest memberProfileUpdateRequest
@@ -56,7 +58,7 @@ public class MemberProfileController {
         return ResponseEntity.ok(memberProfileResponse);
     }
 
-    @GetMapping("/statuses")
+    @GetMapping("/member-profiles/statuses")
     public ResponseEntity<MemberProfileStatusResponse> readMemberProfileStatus(
         @Parameter(hidden = true) @User LoginUser loginUser) {
         MemberProfileStatusResponse memberProfileStatusResponse = memberProfileService.readMemberProfileStatus(
@@ -65,14 +67,33 @@ public class MemberProfileController {
         return ResponseEntity.ok(memberProfileStatusResponse);
     }
 
-    @PatchMapping("/statuses")
+    @PatchMapping("/member-profiles/statuses")
     public ResponseEntity<MemberProfileStatusResponse> updateMemberProfileStatus(
         @Parameter(hidden = true) @User LoginUser loginUser,
-        @RequestBody @Valid MemberProfileStatusUpdateRequest memberProfileStatusUpdateRequest) {
+        @RequestBody @Valid MemberProfileStatusUpdateRequest memberProfileStatusUpdateRequest
+    ) {
         MemberProfileStatusResponse memberProfileStatusResponse = memberProfileService.updateMemberProfileStatus(
             loginUser.getMemberId(), memberProfileStatusUpdateRequest.toDto());
 
         return ResponseEntity.ok(memberProfileStatusResponse);
+    }
+
+    @PatchMapping("/members/me/profile/profile-image")
+    public ResponseEntity<Void> updateMemberProfileImage(
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid MemberProfileImageUpdateRequest request
+    ) {
+        memberProfileService.updateMemberProfileImage(loginUser.getMemberId(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/members/me/profile/open-kakao-room")
+    public ResponseEntity<Void> updateMemberOpenKakaoRoom(
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid MemberProfileOpenKakaoRoomUrlUpdateRequest request
+    ) {
+        memberProfileService.updateMemberProfileOpenKakaoRoom(loginUser.getMemberId(), request);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
@@ -92,7 +92,7 @@ public class MemberProfileController {
             @Parameter(hidden = true) @User LoginUser loginUser,
             @RequestBody @Valid MemberProfileOpenKakaoRoomUrlUpdateRequest request
     ) {
-        memberProfileService.updateMemberProfileOpenKakaoRoom(loginUser.getMemberId(), request);
+        memberProfileService.updateMemberProfileKakaoRoom(loginUser.getMemberId(), request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberProfileController.java
@@ -11,6 +11,7 @@ import com.bookbla.americano.domain.member.controller.dto.response.MemberProfile
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileStatusResponse;
 import com.bookbla.americano.domain.member.service.MemberProfileService;
 import io.swagger.v3.oas.annotations.Parameter;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,8 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
-
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
@@ -32,48 +31,48 @@ public class MemberProfileController {
 
     @PostMapping("/member-profiles")
     public ResponseEntity<MemberProfileResponse> createMemberProfile(
-        @Parameter(hidden = true) @User LoginUser loginUser,
-        @RequestBody @Valid MemberProfileCreateRequest memberProfileCreateRequest) {
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid MemberProfileCreateRequest memberProfileCreateRequest) {
         MemberProfileResponse memberProfileResponse = memberProfileService.createMemberProfile(
-            loginUser.getMemberId(), memberProfileCreateRequest.toMemberProfileDto());
+                loginUser.getMemberId(), memberProfileCreateRequest.toMemberProfileDto());
 
         return ResponseEntity.ok(memberProfileResponse);
     }
 
     @GetMapping("/member-profiles")
     public ResponseEntity<MemberProfileResponse> readMemberProfile(
-        @Parameter(hidden = true) @User LoginUser loginUser) {
+            @Parameter(hidden = true) @User LoginUser loginUser) {
         MemberProfileResponse memberProfileResponse = memberProfileService.readMemberProfile(
-            loginUser.getMemberId());
+                loginUser.getMemberId());
         return ResponseEntity.ok(memberProfileResponse);
     }
 
     @PutMapping("/member-profiles")
     public ResponseEntity<MemberProfileResponse> updateMemberProfile(
-        @Parameter(hidden = true) @User LoginUser loginUser,
-        @RequestBody @Valid MemberProfileUpdateRequest memberProfileUpdateRequest
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid MemberProfileUpdateRequest memberProfileUpdateRequest
     ) {
         MemberProfileResponse memberProfileResponse = memberProfileService.updateMemberProfile(
-            loginUser.getMemberId(), memberProfileUpdateRequest);
+                loginUser.getMemberId(), memberProfileUpdateRequest);
         return ResponseEntity.ok(memberProfileResponse);
     }
 
     @GetMapping("/member-profiles/statuses")
     public ResponseEntity<MemberProfileStatusResponse> readMemberProfileStatus(
-        @Parameter(hidden = true) @User LoginUser loginUser) {
+            @Parameter(hidden = true) @User LoginUser loginUser) {
         MemberProfileStatusResponse memberProfileStatusResponse = memberProfileService.readMemberProfileStatus(
-            loginUser.getMemberId());
+                loginUser.getMemberId());
 
         return ResponseEntity.ok(memberProfileStatusResponse);
     }
 
     @PatchMapping("/member-profiles/statuses")
     public ResponseEntity<MemberProfileStatusResponse> updateMemberProfileStatus(
-        @Parameter(hidden = true) @User LoginUser loginUser,
-        @RequestBody @Valid MemberProfileStatusUpdateRequest memberProfileStatusUpdateRequest
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid MemberProfileStatusUpdateRequest memberProfileStatusUpdateRequest
     ) {
         MemberProfileStatusResponse memberProfileStatusResponse = memberProfileService.updateMemberProfileStatus(
-            loginUser.getMemberId(), memberProfileStatusUpdateRequest.toDto());
+                loginUser.getMemberId(), memberProfileStatusUpdateRequest.toDto());
 
         return ResponseEntity.ok(memberProfileStatusResponse);
     }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileImageUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileImageUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.bookbla.americano.domain.member.controller.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class MemberProfileImageUpdateRequest {
+
+    @NotBlank(message = "프로필 이미지 링크가 입력되지 않았습니다")
+    private String profileImageUrl;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileOpenKakaoRoomUrlUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileOpenKakaoRoomUrlUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.bookbla.americano.domain.member.controller.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class MemberProfileOpenKakaoRoomUrlUpdateRequest {
+
+    @NotBlank(message = "오픈 카카오톡 방 링크가 입력되지 않았습니다.")
+    private String openKakaoRoomUrl;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileUpdateRequest.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.member.controller.dto.request;
 import com.bookbla.americano.domain.member.enums.Gender;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -51,9 +52,10 @@ public class MemberProfileUpdateRequest {
     }
 
     public String toVerifyDescription() {
-        return "name: " + name +
-                ", schoolName: " + schoolName +
-                ", birthDate: " + birthDate;
+        return "name: " + getName() +
+                ", schoolName: " + getSchoolName() +
+                ", birthDate: " + getBirthDate().format(DateTimeFormatter.BASIC_ISO_DATE) +
+                ", gender: " + gender;
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberProfileUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.bookbla.americano.domain.member.controller.dto.request;
 
 import com.bookbla.americano.domain.member.enums.Gender;
+
 import java.time.LocalDate;
+
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -46,6 +48,12 @@ public class MemberProfileUpdateRequest {
 
     public Gender getGender() {
         return Gender.from(gender);
+    }
+
+    public String toVerifyDescription() {
+        return "name: " + name +
+                ", schoolName: " + schoolName +
+                ", birthDate: " + birthDate;
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/member/enums/OpenKakaoRoomStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/member/enums/OpenKakaoRoomStatus.java
@@ -1,24 +1,26 @@
 package com.bookbla.americano.domain.member.enums;
 
-import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.member.exception.MemberProfileException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.member.exception.MemberProfileException;
+
 public enum OpenKakaoRoomStatus {
 
-    PENDING,
-    INACCESSIBLE,
-    NOT_DEFAULT,
-    DONE,
+    PENDING, // 첫 등록 대기
+    CHANGING, // 변경 대기
+    INACCESSIBLE, // 접근 불가
+    NOT_DEFAULT, // 기본 프로필 아님
+    DONE, // 변경 대기
     ;
 
     public static OpenKakaoRoomStatus from(String name) {
         return Arrays.stream(values())
-            .filter(it -> it.name().equalsIgnoreCase(name))
-            .findFirst()
-            .orElseThrow(() -> new BaseException(MemberProfileException.OKA_STATUS_NOT_VALID));
+                .filter(it -> it.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new BaseException(MemberProfileException.OKA_STATUS_NOT_VALID));
     }
 
     public static List<String> getValues() {

--- a/src/main/java/com/bookbla/americano/domain/member/enums/ProfileImageStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/member/enums/ProfileImageStatus.java
@@ -8,9 +8,10 @@ import java.util.stream.Collectors;
 
 public enum ProfileImageStatus {
 
-    PENDING,
-    DENIAL,
-    DONE,
+    PENDING, // 첫 등록
+    DENIAL, // 거절 됨
+    DONE, // 완료
+    CHANGING, // 변경 대기
     ;
 
     public static ProfileImageStatus from(String name) {

--- a/src/main/java/com/bookbla/americano/domain/member/exception/MemberPostcardExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/member/exception/MemberPostcardExceptionType.java
@@ -1,0 +1,19 @@
+package com.bookbla.americano.domain.member.exception;
+
+import com.bookbla.americano.base.exception.ExceptionType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberPostcardExceptionType implements ExceptionType {
+
+    INVALID_POSTCARD_COUNTS(HttpStatus.BAD_REQUEST, "member-post-card_001", "엽서 개수가 부족합니다. 충전 시간을 확인해주세요"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPostcard.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberPostcard.java
@@ -2,14 +2,7 @@ package com.bookbla.americano.domain.member.repository.entity;
 
 import com.bookbla.americano.base.entity.BaseUpdateEntity;
 import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.postcard.enums.PostcardPayType;
-import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import com.bookbla.americano.domain.member.exception.MemberPostcardExceptionType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -17,6 +10,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -41,32 +39,18 @@ public class MemberPostcard extends BaseUpdateEntity {
     @Builder.Default
     private int freePostcardCount = 1;
 
-    public void use(PostcardPayType payType) {
-        validate(payType);
-        if (payType == PostcardPayType.FREE) {
-            freePostcardCount -= 1;
-        } else {
-            payPostcardCount -= 1;
+    public void use() {
+        if (freePostcardCount >= 1) {
+            freePostcardCount--;
+            return;
         }
+        validate();
+        payPostcardCount--;
     }
 
-    public void validate(PostcardPayType payType) {
-        if (payType == PostcardPayType.FREE) {
-            validateFreePostcardCount();
-        } else {
-            validatePayPostcardCount();
-        }
-    }
-
-    private void validateFreePostcardCount() {
-        if (freePostcardCount <= 0) {
-            throw new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID);
-        }
-    }
-
-    private void validatePayPostcardCount() {
-        if (payPostcardCount <= 0) {
-            throw new BaseException(PostcardExceptionType.POSTCARD_TYPE_NOT_VALID);
+    public void validate() {
+        if (freePostcardCount <= 0 && payPostcardCount <= 0) {
+            throw new BaseException(MemberPostcardExceptionType.INVALID_POSTCARD_COUNTS);
         }
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberVerify.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberVerify.java
@@ -26,6 +26,8 @@ import static com.bookbla.americano.domain.member.enums.MemberVerifyStatus.SUCCE
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberVerify extends BaseInsertEntity {
 
+    public static final String DESCRIPTION_PARSING_FAIL = "승인 도중 파싱 실패. 확인 필요";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,7 +37,10 @@ public class MemberVerify extends BaseInsertEntity {
     // 이미지 혹은 카카오톡방 링크
     private String contents;
 
-    // 부가정보
+    // 부가정보,
+    // 학생증 정보 저장시,
+    // "name: 이길여, major: 의학과, schoolName: 서울대학교, studentNumber: 1959xxxx"
+    // 와같이 Map을 String으로 파싱해서 넣은 형태
     private String description;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberProfileService.java
@@ -31,4 +31,6 @@ public interface MemberProfileService {
 
     void updateMemberProfileImage(Long memberId, MemberProfileImageUpdateRequest request);
 
+    void updateMemberProfileKakaoRoom(Long memberId, MemberProfileOpenKakaoRoomUrlUpdateRequest request);
+
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/MemberProfileService.java
@@ -1,14 +1,16 @@
 package com.bookbla.americano.domain.member.service;
 
+import java.util.List;
+
 import com.bookbla.americano.domain.member.controller.dto.request.MemberBookProfileRequestDto;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileImageUpdateRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileOpenKakaoRoomUrlUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberProfileUpdateRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookProfileResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileStatusResponse;
 import com.bookbla.americano.domain.member.service.dto.MemberProfileDto;
 import com.bookbla.americano.domain.member.service.dto.MemberProfileStatusDto;
-
-import java.util.List;
 
 public interface MemberProfileService {
 
@@ -26,5 +28,7 @@ public interface MemberProfileService {
 
     MemberProfileStatusResponse updateMemberProfileStatus(Long memberId,
                                                           MemberProfileStatusDto memberProfileStatusDto);
+
+    void updateMemberProfileImage(Long memberId, MemberProfileImageUpdateRequest request);
 
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/dto/MemberProfileDto.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/dto/MemberProfileDto.java
@@ -1,10 +1,12 @@
 package com.bookbla.americano.domain.member.service.dto;
 
 import com.bookbla.americano.domain.member.enums.Gender;
-import com.bookbla.americano.domain.member.enums.OpenKakaoRoomStatus;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.bookbla.americano.domain.member.repository.entity.MemberVerify;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +29,7 @@ public class MemberProfileDto {
     private String openKakaoRoomUrl;
     private String studentIdImageUrl;
 
-    public MemberProfile toEntity() {
+    public MemberProfile toMemberProfile() {
         return MemberProfile.builder()
             .name(name)
             .birthDate(birthDate)
@@ -35,9 +37,12 @@ public class MemberProfileDto {
             .schoolName(schoolName)
             .schoolEmail(schoolEmail)
             .phoneNumber(phoneNumber)
-            .profileImageUrl(profileImageUrl)
-            .openKakaoRoomUrl(openKakaoRoomUrl)
-            .studentIdImageUrl(studentIdImageUrl)
             .build();
+    }
+    public String toMemberVerifyDescription() {
+        return "name: " + getName() +
+                ", schoolName: " + getSchoolName() +
+                ", birthDate: " + getBirthDate().format(DateTimeFormatter.BASIC_ISO_DATE) +
+                ", gender: " + gender.name();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberProfileServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberProfileServiceImpl.java
@@ -118,20 +118,16 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     @Transactional
     public MemberProfileStatusResponse updateMemberProfileStatus(
             Long memberId,
-            MemberProfileStatusDto memberProfileStatusDto
+            MemberProfileStatusDto dto
     ) {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberProfile memberProfile = member.getMemberProfile();
 
-        updateStatusEntity(memberProfile, memberProfileStatusDto);
-
-        return MemberProfileStatusResponse.from(memberProfile);
-    }
-
-    private void updateStatusEntity(MemberProfile memberprofile, MemberProfileStatusDto dto) {
-        memberprofile.updateProfileImageStatus(dto.getProfileImageStatus())
+        memberProfile.updateProfileImageStatus(dto.getProfileImageStatus())
                 .updateOpenKakaoRoomStatus(dto.getOpenKakaoRoomStatus())
                 .updateStudentIdImageStatus(dto.getStudentIdImageStatus());
+
+        return MemberProfileStatusResponse.from(memberProfile);
     }
 
     @Override
@@ -151,6 +147,26 @@ public class MemberProfileServiceImpl implements MemberProfileService {
 
         MemberProfile memberProfile = member.getMemberProfile();
         memberProfile.updateProfileImageUrl(request.getProfileImageUrl())
+                .updateProfileImageStatus(ProfileImageStatus.CHANGING);
+    }
+
+    @Override
+    @Transactional
+    public void updateMemberProfileKakaoRoom(
+            Long memberId, MemberProfileOpenKakaoRoomUrlUpdateRequest request
+    ) {
+        Member member = memberRepository.getByIdOrThrow(memberId);
+
+        MemberVerify memberVerify = MemberVerify.builder()
+                .memberId(member.getId())
+                .contents(request.getOpenKakaoRoomUrl())
+                .verifyType(MemberVerifyType.OPEN_KAKAO_ROOM_URL)
+                .verifyStatus(MemberVerifyStatus.PENDING)
+                .build();
+        memberVerifyRepository.save(memberVerify);
+
+        MemberProfile memberProfile = member.getMemberProfile();
+        memberProfile.updateProfileImageUrl(request.getOpenKakaoRoomUrl())
                 .updateProfileImageStatus(ProfileImageStatus.CHANGING);
     }
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
@@ -1,7 +1,7 @@
 package com.bookbla.americano.domain.postcard.service.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -23,14 +23,9 @@ public class SendPostcardRequest {
     @NotNull(message = "엽서를 보낼 상대방의 식별자가 입력되지 않았습니다")
     private Long receiveMemberId;
 
-    private Long memberAskId;
-
     @NotNull(message = "memberReply가 입력되지 않았습니다.")
     @Size(max = 150)
     private String memberReply;
-
-    @Schema(description = "엽서의 유료/무료 타입", example = "Free/Pay")
-    private String postcardPayType;
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -64,8 +64,7 @@ public class PostcardServiceImpl implements PostcardService {
     public SendPostcardResponse send(Long memberId, SendPostcardRequest request) {
         MemberPostcard memberPostcard = memberPostcardRepository.findMemberPostcardByMemberId(memberId)
                 .orElseThrow(() -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
-        PostcardPayType payType = PostcardPayType.from(request.getPostcardPayType());
-        memberPostcard.validate(payType);
+        memberPostcard.validate();
 
         List<Postcard> sentPostcards = postcardRepository.findBySendMemberIdAndReceiveMemberId(memberId, request.getReceiveMemberId());
         sentPostcards.forEach(Postcard::validateSendPostcard);
@@ -102,7 +101,7 @@ public class PostcardServiceImpl implements PostcardService {
 
         PostcardStatus status = isCorrect ? PostcardStatus.PENDING : PostcardStatus.ALL_WRONG;
 
-        memberPostcard.use(payType);
+        memberPostcard.use();
 
         PostcardType postCardType = postcardTypeRepository.getByIdOrThrow(request.getPostcardTypeId());
         Postcard postcard = Postcard.builder()

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -35,6 +35,7 @@ class PostcardServiceTest {
     @Autowired
     private PostcardRepository postcardRepository;
 
+
     @EnumSource(mode = INCLUDE, names = {"PENDING", "ACCEPT", "ALL_WRONG"})
     @ParameterizedTest(name = "엽서를_보낼_수_없다면_예외를_반환한다")
     void 엽서를_보낼_수_없다면_예외를_반환한다(PostcardStatus postcardStatus) {
@@ -89,6 +90,5 @@ class PostcardServiceTest {
     @AfterEach
     void tearDown() {
         postcardRepository.deleteAll();
-        memberRepository.deleteAll();
     }
 }


### PR DESCRIPTION
## 📄 Summary

> 엽서 사용 로직 변경

기존 : 유/무료를 사용자가 직접 선택하게 함
변경 후 : 
1) 무료엽서 개수 확인
2) 있으면 차감 후 종료
3) 없다면 유료엽서 확인
4) 무료/유료 엽서 개수 모두 확인
5) 없다면 예외
6) 유료 엽서 차감

엽서 검증 변경 -> 무료 엽서와 유료 엽서 모두 없다면 예외 던짐

> 프로필 변경시 임시 테이블 사용하도록 변경

## 🙋🏻 More

>