### PR TITLE
fix: 프로필/카톡방 승인 대기 상태에서 다시 변경 요청하는 경우의 방어로직 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberVerifyRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberVerifyRepository.java
@@ -11,6 +11,7 @@ import feign.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface MemberVerifyRepository extends JpaRepository<MemberVerify, Long> {
@@ -31,4 +32,11 @@ public interface MemberVerifyRepository extends JpaRepository<MemberVerify, Long
             "and mv.verifyType = com.bookbla.americano.domain.member.enums.MemberVerifyType.PROFILE_IMAGE " +
             "order by mv.id desc ")
     List<String> findMemberPendingProfileImage(@Param("memberId") Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from MemberVerify mv " +
+            "where mv.memberId = :memberId " +
+            "and mv.verifyStatus = com.bookbla.americano.domain.member.enums.MemberVerifyStatus.PENDING " +
+            "and mv.verifyType = :verifyType")
+    void deleteMemberPendingVerifies(Long memberId, MemberVerifyType verifyType);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/MemberVerifyRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/MemberVerifyRepository.java
@@ -1,6 +1,6 @@
 package com.bookbla.americano.domain.member.repository;
 
-import java.util.Optional;
+import java.util.List;
 
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.enums.MemberVerifyStatus;
@@ -28,6 +28,7 @@ public interface MemberVerifyRepository extends JpaRepository<MemberVerify, Long
             "from MemberVerify mv " +
             "where mv.memberId = :memberId " +
             "and mv.verifyStatus = com.bookbla.americano.domain.member.enums.MemberVerifyStatus.PENDING " +
-            "and mv.verifyType = com.bookbla.americano.domain.member.enums.MemberVerifyType.PROFILE_IMAGE ")
-    Optional<String> findMemberPendingProfileImage(@Param("memberId") Long memberId);
+            "and mv.verifyType = com.bookbla.americano.domain.member.enums.MemberVerifyType.PROFILE_IMAGE " +
+            "order by mv.id desc ")
+    List<String> findMemberPendingProfileImage(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberBookServiceImpl.java
@@ -1,7 +1,6 @@
 package com.bookbla.americano.domain.member.service.impl;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.book.repository.BookRepository;
@@ -80,10 +79,7 @@ public class MemberBookServiceImpl implements MemberBookService {
     @Override
     @Transactional(readOnly = true)
     public MemberBookReadResponse readMemberBook(Long memberId, Long memberBookId) {
-        Member member = memberRepository.getByIdOrThrow(memberId);
         MemberBook memberBook = memberBookRepository.getByIdOrThrow(memberBookId);
-
-        memberBook.validateOwner(member);
         QuizQuestion quizQuestion = quizQuestionRepository.findByMemberBook(memberBook)
                 .orElseThrow(() -> new BaseException(QuizQuestionExceptionType.MEMBER_QUIZ_QUESTION_NOT_FOUND));
 

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberLibraryServiceImpl.java
@@ -32,6 +32,8 @@ public class MemberLibraryServiceImpl implements MemberLibraryService {
         List<MemberBook> memberBooks = memberBookRepository.findByMemberOrderByCreatedAt(member);
 
         return memberVerifyRepository.findMemberPendingProfileImage(member.getId())
+                .stream()
+                .findFirst()
                 .map(image -> MemberLibraryProfileReadResponse.ofPendingProfileImage(member, memberBooks, image))
                 .orElseGet(() -> MemberLibraryProfileReadResponse.of(member, memberBooks));
     }

--- a/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberProfileServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/service/impl/MemberProfileServiceImpl.java
@@ -17,7 +17,6 @@ import com.bookbla.americano.domain.member.controller.dto.response.MemberBookPro
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileStatusResponse;
 import com.bookbla.americano.domain.member.enums.MemberStatus;
-import com.bookbla.americano.domain.member.enums.MemberVerifyType;
 import com.bookbla.americano.domain.member.enums.OpenKakaoRoomStatus;
 import com.bookbla.americano.domain.member.enums.ProfileImageStatus;
 import com.bookbla.americano.domain.member.exception.MemberEmailExceptionType;
@@ -35,6 +34,10 @@ import com.bookbla.americano.domain.member.service.dto.MemberProfileStatusDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.bookbla.americano.domain.member.enums.MemberVerifyType.OPEN_KAKAO_ROOM_URL;
+import static com.bookbla.americano.domain.member.enums.MemberVerifyType.PROFILE_IMAGE;
+import static com.bookbla.americano.domain.member.enums.MemberVerifyType.STUDENT_ID;
 
 
 @Service
@@ -65,29 +68,32 @@ public class MemberProfileServiceImpl implements MemberProfileService {
     }
 
     private void saveStudentIdVerify(Member member, String verifyDescription, String studentImageUrl) {
+        memberVerifyRepository.deleteMemberPendingVerifies(member.getId(), STUDENT_ID);
         MemberVerify studentIdVerify = MemberVerify.builder()
                 .memberId(member.getId())
                 .description(verifyDescription)
                 .contents(studentImageUrl)
-                .verifyType(MemberVerifyType.STUDENT_ID)
+                .verifyType(STUDENT_ID)
                 .build();
         memberVerifyRepository.save(studentIdVerify);
     }
 
     private void saveProfileImageVerify(Member member, String imageUrl) {
+        memberVerifyRepository.deleteMemberPendingVerifies(member.getId(), PROFILE_IMAGE);
         MemberVerify profileImageVerify = MemberVerify.builder()
                 .memberId(member.getId())
                 .contents(imageUrl)
-                .verifyType(MemberVerifyType.PROFILE_IMAGE)
+                .verifyType(PROFILE_IMAGE)
                 .build();
         memberVerifyRepository.save(profileImageVerify);
     }
 
     private void saveKakaoRoomVerify(Member member, String kakaoRoomUrl) {
+        memberVerifyRepository.deleteMemberPendingVerifies(member.getId(), OPEN_KAKAO_ROOM_URL);
         MemberVerify kakaoRoomVerify = MemberVerify.builder()
                 .memberId(member.getId())
                 .contents(kakaoRoomUrl)
-                .verifyType(MemberVerifyType.OPEN_KAKAO_ROOM_URL)
+                .verifyType(OPEN_KAKAO_ROOM_URL)
                 .build();
         memberVerifyRepository.save(kakaoRoomVerify);
     }


### PR DESCRIPTION
## 📄 Summary

>

인증 요청시 기존 검증 대기 요청 제거하도록 변경
내 서재에서 검증 요청 여부 확인시 한 개가 아닌 여러개로 받아, 최신 요청을 가지고 오도록 수정


## 🙋🏻 More

>