### PR TITLE
Fix: 매칭_받은 엽서(postcard/to) api 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -88,8 +88,9 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                 .innerJoin(memberAsk).on(member.eq(memberAsk.member))
                 .innerJoin(memberReply).on(postcard.memberReply.eq(memberReply))
                 .where(postcard.receiveMember.id.eq(memberId)
-                        .and(postcard.postcardStatus.eq(PostcardStatus.REFUSED).not())
-                        .and(postcard.postcardStatus.eq(PostcardStatus.ALL_WRONG).not()))
+                        .and(postcard.postcardStatus.eq(PostcardStatus.PENDING)
+                                .or(postcard.postcardStatus.eq(PostcardStatus.READ))
+                                .or(postcard.postcardStatus.eq(PostcardStatus.ACCEPT))))
                 .orderBy(postcard.sendMember.id.asc())
                 .fetch();
     }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.bookbla.americano.domain.member.repository.entity.QMember;
 import com.bookbla.americano.domain.member.repository.entity.QMemberBook;
 import com.bookbla.americano.domain.memberask.repository.entity.QMemberAsk;
 import com.bookbla.americano.domain.memberask.repository.entity.QMemberReply;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.repository.custom.PostcardRepositoryCustom;
 import com.bookbla.americano.domain.postcard.repository.entity.QPostcard;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
@@ -86,7 +87,9 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                 .innerJoin(member).on(memberBook.member.eq(member))
                 .innerJoin(memberAsk).on(member.eq(memberAsk.member))
                 .innerJoin(memberReply).on(postcard.memberReply.eq(memberReply))
-                .where(postcard.receiveMember.id.eq(memberId))
+                .where(postcard.receiveMember.id.eq(memberId)
+                        .and(postcard.postcardStatus.eq(PostcardStatus.REFUSED).not())
+                        .and(postcard.postcardStatus.eq(PostcardStatus.ALL_WRONG).not()))
                 .orderBy(postcard.sendMember.id.asc())
                 .fetch();
     }


### PR DESCRIPTION
## 📄 Summary

> 받은 엽서(postcard/to) 호출 시, 읽기 전(PENDING), 읽음(READ), 수락(ACCEPT) 상태인 엽서만 읽어오도록 수정

## 🙋🏻 More

> 혹시 DB에 직접 접근하거나, 엽서 상태 변경 시 이상한 값이 들어가 엽서 상태가 이상한 값으로 저장되어 있는 경우, 이상한 상태로 저장 된 엽서도 보내지지 않게 하기 위하여 "읽기 전", "읽음", "수락" 상태 외의 다른 상태는 보내지지 않도록 수정하였습니다. 
> 엽서 상태를 변경하는 api에 이상한 상태로 변경 요청을 하면 Exception(Bad Request)이 나도록 되어있긴 하지만, 혹시나 저장 될 수 있을 것 같아 "받은 엽서"에서 읽을 수 있는 엽서 상태가 아니라면 보내지 않도록 수정하였습니다.