### PR TITLE
fix: (Home)`all-other-members` api 수정 및 (Matching)이름 마스킹 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/custom/impl/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/custom/impl/MemberRepositoryCustomImpl.java
@@ -15,6 +15,7 @@ import com.bookbla.americano.domain.member.enums.DrinkType;
 import com.bookbla.americano.domain.member.enums.Gender;
 import com.bookbla.americano.domain.member.enums.JustFriendType;
 import com.bookbla.americano.domain.member.enums.Mbti;
+import com.bookbla.americano.domain.member.enums.MemberStatus;
 import com.bookbla.americano.domain.member.enums.SmokeType;
 import com.bookbla.americano.domain.member.repository.custom.MemberRepositoryCustom;
 import com.bookbla.americano.domain.member.repository.entity.QMember;
@@ -110,7 +111,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .from(member)
                 .innerJoin(memberBook).on(member.eq(memberBook.member))
                 .innerJoin(book).on(memberBook.book.eq(book).and(memberBook.isDeleted.eq(false)))
-                .where(builder.andNot(member.id.eq(memberId)))
+                .where(builder.andNot(member.id.eq(memberId))
+                        .and(member.memberStatus.eq(MemberStatus.COMPLETED)))
                 .orderBy(member.createdAt.desc())
                 .fetch();
     }

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardFromResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardFromResponse.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 
 @Getter
@@ -47,16 +49,33 @@ public class MemberPostcardFromResponse {
 
     private PostcardStatus postcardStatus;
 
-    public MemberPostcardFromResponse(long memberId, String memberName, int memberAge, Gender memberGender, String memberSchoolName,
-                                      String memberProfileImageUrl, String memberOpenKakaoRoomUrl, long postcardId, PostcardStatus postcardStatus) {
+    public MemberPostcardFromResponse(long memberId, String memberName, LocalDate memberBirthDate, Gender memberGender,
+                                      String memberSchoolName, String memberProfileImageUrl, String memberOpenKakaoRoomUrl,
+                                      long postcardId, PostcardStatus postcardStatus) {
         this.memberId = memberId;
-        this.memberName = memberName;
-        this.memberAge = memberAge;
+        if(postcardStatus.equals(PostcardStatus.ACCEPT)){
+            this.memberName = memberName;
+        } else {
+            this.memberName = transformMemberName(memberName);
+        }
+        this.memberAge = getAge(memberBirthDate);
         this.memberGender = memberGender;
         this.memberSchoolName = memberSchoolName;
         this.memberProfileImageUrl = memberProfileImageUrl;
         this.memberOpenKakaoRoomUrl = memberOpenKakaoRoomUrl;
         this.postcardId = postcardId;
         this.postcardStatus = postcardStatus;
+    }
+
+    private String transformMemberName(String name){
+        if(name == null || name.isEmpty())
+            return "";
+        char lastName = name.charAt(0);
+        return lastName +
+                "O".repeat(name.length() - 1);
+    }
+
+    private int getAge(LocalDate birthDay) {
+        return Period.between(birthDay, LocalDate.now()).getYears();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardToResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardToResponse.java
@@ -5,6 +5,8 @@ import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.quiz.enums.CorrectStatus;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 
 @Getter
@@ -63,16 +65,20 @@ public class MemberPostcardToResponse {
     private List<String> bookImageUrls;
 
     public MemberPostcardToResponse(long postcardId, long memberId, String memberName, String memberProfileImageUrl,
-                                    int memberAge, Gender memberGender, DrinkType drinkType, SmokeType smokeType,
+                                    LocalDate memberBirthDate, Gender memberGender, DrinkType drinkType, SmokeType smokeType,
                                     ContactType contactType, DateStyleType dateStyleType, DateCostType dateCostType,
                                     Mbti mbti, JustFriendType justFriendType, String memberSchoolName, String memberReplyContent,
                                     PostcardStatus postcardStatus, String postcardImageUrl, String memberKakaoRoomUrl) {
 
         this.postcardId = postcardId;
         this.memberId = memberId;
-        this.memberName = memberName;
+        if(postcardStatus.equals(PostcardStatus.ACCEPT)){
+            this.memberName = memberName;
+        } else {
+            this.memberName = transformMemberName(memberName);
+        }
         this.memberProfileImageUrl = memberProfileImageUrl;
-        this.memberAge = memberAge;
+        this.memberAge = getAge(memberBirthDate);
         this.memberGender = memberGender.name();
         this.drinkType = drinkType.getValue();
         this.smokeType = smokeType.getValue();
@@ -86,5 +92,17 @@ public class MemberPostcardToResponse {
         this.postcardStatus = postcardStatus;
         this.postcardImageUrl = postcardImageUrl;
         this.memberOpenKakaoRoomUrl = memberKakaoRoomUrl;
+    }
+
+    private String transformMemberName(String name){
+        if(name == null || name.isEmpty())
+            return "";
+        char lastName = name.charAt(0);
+        return lastName +
+                "O".repeat(name.length() - 1);
+    }
+
+    private int getAge(LocalDate birthDay) {
+        return Period.between(birthDay, LocalDate.now()).getYears();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -38,8 +38,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -144,8 +142,7 @@ public class PostcardServiceImpl implements PostcardService {
                     i.getMemberId());
             List<String> nowBookImageUrls = new ArrayList<>();
             nowResponse = new MemberPostcardFromResponse(i.getMemberId(), i.getMemberName(),
-                    getAge(i.getMemberBirthDate()),
-                    i.getMemberGender(), i.getMemberSchoolName(), i.getMemberProfileImageUrl(),
+                    i.getMemberBirthDate(), i.getMemberGender(), i.getMemberSchoolName(), i.getMemberProfileImageUrl(),
                     i.getMemberOpenKakaoRoomUrl(), i.getPostcardId(), i.getPostcardStatus());
             for (MemberBookReadResponses.MemberBookReadResponse j : memberBookList.getMemberBookReadResponses()) {
                 if (j.isRepresentative()) {
@@ -161,10 +158,6 @@ public class PostcardServiceImpl implements PostcardService {
         }
 
         return memberPostcardFromResponseList;
-    }
-
-    private int getAge(LocalDate birthDay) {
-        return Period.between(birthDay, LocalDate.now()).getYears();
     }
 
     @Override // 받은 엽서
@@ -189,13 +182,10 @@ public class PostcardServiceImpl implements PostcardService {
                 }
                 // 초기화
                 now = i.getMemberId();
-                int age = getAge(i.getMemberBirthDate());
                 nowResponse = new MemberPostcardToResponse(i.getPostcardId(), i.getMemberId(),
-                        i.getMemberName(),
-                        i.getMemberProfileImageUrl(), age, i.getMemberGender(), i.getDrinkType(),
-                        i.getSmokeType(),
-                        i.getContactType(), i.getDateStyleType(), i.getDateCostType(), i.getMbti(),
-                        i.getJustFriendType(),
+                        i.getMemberName(), i.getMemberProfileImageUrl(), i.getMemberBirthDate(), i.getMemberGender(),
+                        i.getDrinkType(), i.getSmokeType(), i.getContactType(), i.getDateStyleType(),
+                        i.getDateCostType(), i.getMbti(), i.getJustFriendType(),
                         i.getMemberSchoolName(), i.getMemberReplyContent(), i.getPostcardStatus(),
                         i.getPostcardImageUrl(), i.getMemberKakaoRoomUrl());
                 nowBookTitles = new ArrayList<>();


### PR DESCRIPTION
## 📄 Summary

>[Home]`all-other-members` api 수정
>- all-other-members 호출 시 **COMPLETE** 상태의 회원들만 보이도록 수정
>
>[Matching] 수락 되지 않은 엽서에서 상대방의 이름 보이지 않도록 수정
>- 받은 엽서, 보낸 엽서 조회 시, 엽서가 **ACCEPT** 상태일때만 상대방의 이름이 모두 뜨도록 수정
>- **ACCEPT** 상태가 아닌 경우에는 `{성}OO`으로 보여지도록 수정

## 🙋🏻 More

>