### PR TITLE
fix: 수락 된 엽서의 상대방 정보를 가져오는 API 추가(postcard/contact-info/{postcardId})

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -5,6 +5,7 @@ import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.member.service.MemberPostcardService;
 import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardSendValidationRequest;
 import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
+import com.bookbla.americano.domain.postcard.controller.dto.response.ContactInfoResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
@@ -17,8 +18,6 @@ import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeRe
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import java.util.List;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +26,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/postcard")
@@ -79,6 +81,13 @@ public class PostcardController {
             @Parameter(hidden = true) @User LoginUser loginUser,
             @PathVariable Long postcardId) {
         return PostcardStatusResponse.from(postcardService.getPostcardStatus(postcardId));
+    }
+
+    @Operation(summary = "상대방 정보 조회", description = "ACCEPT 엽서의 상대방 정보 조회")
+    @GetMapping("/contact-info/{postcardId}")
+    public ResponseEntity<ContactInfoResponse> getContactInfo(
+            @Parameter(hidden = true) @User LoginUser loginUser, @PathVariable Long postcardId) {
+        return ResponseEntity.ok(postcardService.getContactInfo(loginUser.getMemberId(), postcardId));
     }
 
     @PostMapping("/send")

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/ContactInfoResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/ContactInfoResponse.java
@@ -1,0 +1,52 @@
+package com.bookbla.americano.domain.postcard.controller.dto.response;
+
+import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
+import com.bookbla.americano.domain.member.enums.Gender;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ContactInfoResponse {
+    private long memberId;
+
+    private String memberName;
+
+    private int memberAge;
+
+    private Gender memberGender;
+
+    private String memberProfileImageUrl;
+
+    private String memberSchoolName;
+
+    private String memberOpenKakaoRoomUrl;
+
+    private List<String> bookImageUrls;
+
+    public ContactInfoResponse(MemberProfileResponse memberProfileResponse, MemberBookReadResponses memberBookReadResponses) {
+        this.memberId = memberProfileResponse.getMemberId();
+        this.memberName = memberProfileResponse.getName();
+        this.memberAge = getAge(LocalDate.parse(memberProfileResponse.getBirthDate()));
+        this.memberGender = Gender.from(memberProfileResponse.getGender());
+        this.memberProfileImageUrl = memberProfileResponse.getProfileImageUrl();
+        this.memberSchoolName = memberProfileResponse.getSchoolName();
+        this.memberOpenKakaoRoomUrl = memberProfileResponse.getOpenKakaoRoomUrl();
+        List<String> imageUrls = new ArrayList<>();
+        for (MemberBookReadResponses.MemberBookReadResponse i : memberBookReadResponses.getMemberBookReadResponses()) {
+            imageUrls.add(i.getThumbnail());
+        }
+        this.bookImageUrls = imageUrls;
+    }
+
+    private int getAge(LocalDate birthDay) {
+        return Period.between(birthDay, LocalDate.now()).getYears();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/exception/PostcardExceptionType.java
@@ -24,6 +24,8 @@ public enum PostcardExceptionType implements ExceptionType {
 
     READ_POSTCARD_ALREADY(HttpStatus.BAD_REQUEST, "postcard-009", "이미 읽은 엽서입니다."),
     ALL_WRONG_POSTCARD(HttpStatus.BAD_REQUEST, "postcard-010", "독서 퀴즈를 모두 틀린 엽서입니다."),
+
+    POSTCARD_NOT_ACCEPTED(HttpStatus.UNPROCESSABLE_ENTITY, "postcard-011", "수락되지 않은 엽서입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -1,5 +1,6 @@
 package com.bookbla.americano.domain.postcard.service;
 
+import com.bookbla.americano.domain.postcard.controller.dto.response.ContactInfoResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
@@ -26,4 +27,6 @@ public interface PostcardService {
     PostcardStatus getPostcardStatus(Long postcardId);
 
     PostcardSendValidateResponse validateSendPostcard(Long memberId, Long targetMemberId);
+
+    ContactInfoResponse getContactInfo(Long memberId, Long postcardId);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/impl/PostcardServiceImpl.java
@@ -3,18 +3,21 @@ package com.bookbla.americano.domain.postcard.service.impl;
 
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
+import com.bookbla.americano.domain.member.controller.dto.response.MemberProfileResponse;
 import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberPostcardRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPostcard;
 import com.bookbla.americano.domain.member.service.MemberBookService;
+import com.bookbla.americano.domain.member.service.MemberProfileService;
 import com.bookbla.americano.domain.memberask.exception.MemberAskExceptionType;
 import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
 import com.bookbla.americano.domain.memberask.repository.MemberReplyRepository;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
 import com.bookbla.americano.domain.notification.service.AlarmService;
+import com.bookbla.americano.domain.postcard.controller.dto.response.ContactInfoResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
@@ -35,12 +38,13 @@ import com.bookbla.americano.domain.quiz.repository.QuizQuestionRepository;
 import com.bookbla.americano.domain.quiz.repository.QuizReplyRepository;
 import com.bookbla.americano.domain.quiz.repository.entity.QuizQuestion;
 import com.bookbla.americano.domain.quiz.repository.entity.QuizReply;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -56,6 +60,7 @@ public class PostcardServiceImpl implements PostcardService {
     private final PostcardTypeRepository postcardTypeRepository;
     private final MemberPostcardRepository memberPostcardRepository;
     private final MemberBookService memberBookService;
+    private final MemberProfileService memberProfileService;
     private final AlarmService alarmService;
 
     @Override
@@ -291,5 +296,28 @@ public class PostcardServiceImpl implements PostcardService {
             sendPostcards.stream()
                 .anyMatch(Postcard::isRefused)
         );
+    }
+
+    @Override
+    public ContactInfoResponse getContactInfo(Long memberId, Long postcardId) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+
+        if (!Objects.equals(postcard.getReceiveMember().getId(), memberId) && !Objects.equals(postcard.getSendMember().getId(), memberId))
+            throw new BaseException(PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD);
+        if (postcard.getPostcardStatus() != PostcardStatus.ACCEPT)
+            throw new BaseException(PostcardExceptionType.POSTCARD_NOT_ACCEPTED);
+
+        if (Objects.equals(postcard.getReceiveMember().getId(), memberId)) {
+            MemberProfileResponse memberProfileResponse = memberProfileService.readMemberProfile(postcard.getSendMember().getId());
+            MemberBookReadResponses memberBookReadResponses = memberBookService.readMemberBooks(postcard.getSendMember().getId());
+            return new ContactInfoResponse(memberProfileResponse, memberBookReadResponses);
+        } else if (Objects.equals(postcard.getSendMember().getId(), memberId)) {
+            MemberProfileResponse memberProfileResponse = memberProfileService.readMemberProfile(postcard.getReceiveMember().getId());
+            MemberBookReadResponses memberBookReadResponses = memberBookService.readMemberBooks(postcard.getReceiveMember().getId());
+            return new ContactInfoResponse(memberProfileResponse, memberBookReadResponses);
+        }
+
+        throw new BaseException(PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD);
     }
 }


### PR DESCRIPTION
## 📄 Summary
> 수락 된 엽서의 상대방 정보를 가져오는 API (postcard/contact-info/{postcardId})
> - **Input** : (LoginUser)memberId, (PathVariable)postcardId
> - **Output** : 상대방 정보 => id, 이름, 나이, 성별, 프로필 이미지, 학교, 카카오 url, 책 이미지(list)
## 🙋🏻 More

>