### PR TITLE
feat: member-reply 읽기, 수정 api 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/memberask/controller/MemberReplyController.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/controller/MemberReplyController.java
@@ -1,0 +1,45 @@
+package com.bookbla.americano.domain.memberask.controller;
+
+import com.bookbla.americano.base.resolver.LoginUser;
+import com.bookbla.americano.base.resolver.User;
+import com.bookbla.americano.domain.memberask.controller.dto.request.MemberReplyUpdateRequest;
+import com.bookbla.americano.domain.memberask.controller.dto.response.MemberReplyResponse;
+import com.bookbla.americano.domain.memberask.service.MemberReplyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/member-reply")
+public class MemberReplyController {
+
+    private final MemberReplyService memberReplyService;
+
+    @Operation(summary = "개인 질문 답변 조회", description = "사용자가 보낸 엽서의 개인 질문 답변 조회")
+    @GetMapping("/{postcardId}")
+    public ResponseEntity<MemberReplyResponse> readMemberReply(
+            @Parameter(hidden = true) @User LoginUser loginUser, @PathVariable Long postcardId) {
+        MemberReplyResponse memberReplyResponse =
+                memberReplyService.readMemberReply(loginUser.getMemberId(), postcardId);
+        return ResponseEntity.ok(memberReplyResponse);
+    }
+
+    @Operation(summary = "개인 질문 답변 수정", description = "사용자가 상대방의 응답을 기다리는 엽서(PENDING 상태)의 개인 질문 답변 수정")
+    @PutMapping
+    public ResponseEntity<Void> updateMemberReply(
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid MemberReplyUpdateRequest memberReplyUpdateRequest) {
+        memberReplyService.updateMemberReply(loginUser.getMemberId(), memberReplyUpdateRequest);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/request/MemberReplyUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/request/MemberReplyUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.bookbla.americano.domain.memberask.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class MemberReplyUpdateRequest {
+    @NotNull(message = "엽서 id가 입력되지 않았습니다.")
+    private Long postcardId;
+    @NotBlank(message = "답변이 입력되지 않았습니다.")
+    private String content;
+}

--- a/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/response/MemberReplyResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/controller/dto/response/MemberReplyResponse.java
@@ -1,0 +1,12 @@
+package com.bookbla.americano.domain.memberask.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberReplyResponse {
+    private final Long memberReplyId;
+    private final String askContent;
+    private final String replyContent;
+}

--- a/src/main/java/com/bookbla/americano/domain/memberask/exception/MemberReplyExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/exception/MemberReplyExceptionType.java
@@ -1,0 +1,17 @@
+package com.bookbla.americano.domain.memberask.exception;
+
+import com.bookbla.americano.base.exception.ExceptionType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberReplyExceptionType implements ExceptionType {
+    IMMUTABLE_POSTCARD(HttpStatus.FORBIDDEN, "member-reply_001", "개인 답변 수정이 불가능한 엽서 입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/bookbla/americano/domain/memberask/repository/entity/MemberReply.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/repository/entity/MemberReply.java
@@ -30,4 +30,8 @@ public class MemberReply extends BaseInsertEntity {
     private MemberAsk memberAsk;
 
     private String content;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/memberask/service/MemberReplyService.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/service/MemberReplyService.java
@@ -1,0 +1,10 @@
+package com.bookbla.americano.domain.memberask.service;
+
+import com.bookbla.americano.domain.memberask.controller.dto.request.MemberReplyUpdateRequest;
+import com.bookbla.americano.domain.memberask.controller.dto.response.MemberReplyResponse;
+
+public interface MemberReplyService {
+    MemberReplyResponse readMemberReply(Long memberId, Long postcardId);
+
+    void updateMemberReply(Long memberId, MemberReplyUpdateRequest memberReplyUpdateRequest);
+}

--- a/src/main/java/com/bookbla/americano/domain/memberask/service/impl/MemberReplyServiceImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/memberask/service/impl/MemberReplyServiceImpl.java
@@ -1,0 +1,54 @@
+package com.bookbla.americano.domain.memberask.service.impl;
+
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.memberask.controller.dto.request.MemberReplyUpdateRequest;
+import com.bookbla.americano.domain.memberask.controller.dto.response.MemberReplyResponse;
+import com.bookbla.americano.domain.memberask.exception.MemberAskExceptionType;
+import com.bookbla.americano.domain.memberask.exception.MemberReplyExceptionType;
+import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
+import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
+import com.bookbla.americano.domain.memberask.service.MemberReplyService;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
+import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberReplyServiceImpl implements MemberReplyService {
+    private final PostcardRepository postcardRepository;
+    private final MemberAskRepository memberAskRepository;
+
+    @Override
+    public MemberReplyResponse readMemberReply(Long memberId, Long postcardId) {
+        Postcard postcard = postcardRepository.findById(postcardId)
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+        if (!Objects.equals(postcard.getSendMember().getId(), memberId)) {
+            throw new BaseException(PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD);
+        }
+
+        MemberAsk memberAsk = memberAskRepository.findByMember(postcard.getReceiveMember())
+                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
+
+        return new MemberReplyResponse(postcard.getMemberReply().getId(),
+                memberAsk.getContents(), postcard.getMemberReply().getContent());
+    }
+
+    @Override
+    public void updateMemberReply(Long memberId, MemberReplyUpdateRequest memberReplyUpdateRequest) {
+        Postcard postcard = postcardRepository.findById(memberReplyUpdateRequest.getPostcardId())
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+        if (!Objects.equals(postcard.getSendMember().getId(), memberId)) {
+            throw new BaseException(PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD);
+        } else if (!postcard.getPostcardStatus().equals(PostcardStatus.PENDING)) {
+            throw new BaseException(MemberReplyExceptionType.IMMUTABLE_POSTCARD);
+        }
+        postcard.getMemberReply().updateContent(memberReplyUpdateRequest.getContent());
+    }
+}


### PR DESCRIPTION
## 📄 Summary
>### member-reply controller 추가 (`/members/member-reply` )
>    - **읽기** - GET(`/{postcardId}`)
>        - **응답** : memberReplyId, askContent(질문), replyContent(답변)
>        - 해당 id의 엽서가 없을 때, `PostcardExceptionType.INVALID_POSTCARD`
>        - 해당 엽서의 보낸 사람이 본인이 아닐 때, `PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD`
>        - 해당 엽서에 등록 된 개인 질문이 없을 때, `MemberAskExceptionType.NOT_REGISTERED_MEMBER`
>    - **수정** - PUT
>        - **요청 Body** : postcardId(엽서 Id), content(수정할 답변)
>        - 해당 id의 엽서가 없을 때, `PostcardExceptionType.INVALID_POSTCARD`
>        - 해당 엽서의 보낸 사람이 본인이 아닐 때, `PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD`
>        - 해당 엽서의 상태가 `PENDING` 상태가 아닐 때, `MemberReplyExceptionType.IMMUTABLE_POSTCARD`
## 🙋🏻 More

>