### PR TITLE
fix: 엽서 전송/수락과 알림 발송을 분리

### DIFF
--- a/src/main/java/com/bookbla/americano/base/config/AsyncConfig.java
+++ b/src/main/java/com/bookbla/americano/base/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.bookbla.americano.base.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/com/bookbla/americano/domain/admin/service/AdminMarketingService.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/service/AdminMarketingService.java
@@ -7,11 +7,10 @@ import com.bookbla.americano.domain.member.repository.MemberPushAlarmRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPushAlarm;
-import com.bookbla.americano.domain.notification.controller.dto.request.PushAlarmAllCreateRequest;
-import com.bookbla.americano.domain.notification.service.AlarmService;
 import com.bookbla.americano.domain.notification.service.NotificationClient;
+import com.bookbla.americano.domain.notification.service.PostcardPushAlarmEventListener;
+import com.bookbla.americano.domain.notification.service.PushAlarmSendAllEvent;
 import com.bookbla.americano.domain.notification.service.dto.NotificationResponse;
-import com.sun.xml.bind.v2.TODO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -22,10 +21,10 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class AdminMarketingService {
 
     private final NotificationClient notificationClient;
-    private final AlarmService alarmService;
     private final MemberRepository memberRepository;
     private final MemberPushAlarmRepository memberPushAlarmRepository;
     private final TransactionTemplate transactionTemplate;
+    private final PostcardPushAlarmEventListener postcardPushAlarmEventListener;
 
     public List<NotificationResponse> sendNotification(NotificationDto notificationDto, Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
@@ -46,24 +45,8 @@ public class AdminMarketingService {
         transactionTemplate.executeWithoutResult(action -> memberPushAlarmRepository.save(memberPushAlarm));
     }
 
-//     TODO: 회원 별 성공/실패 결과 전달할 방법?
-//     TODO: expo는 토큰 보낸 순서대로 data를 보내줌
     public void sendNotifications(NotificationDto dto) {
-        alarmService.sendPushAlarmAll(new PushAlarmAllCreateRequest(dto.getTitle(), dto.getContents()));
-//        List<Member> members = memberRepository.findByMemberStatus(COMPLETED, MATCHING_DISABLED);
-//        Map<Member, String> sendableMemberTokenMap = members.stream()
-//                .filter(Member::canSendAdvertisementAlarm)
-//                .collect(Collectors.toMap(
-//                        Function.identity(),
-//                        Member::getPushToken
-//                ));
+        postcardPushAlarmEventListener.sendAll(new PushAlarmSendAllEvent(dto.getTitle(), dto.getContents()));
     }
-//
-//    private List<String> toTokens(Map<Member, String> memberTokens) {
-//        return memberTokens.keySet()
-//                .stream()
-//                .map(memberTokens::get)
-//                .collect(Collectors.toList());
-//    }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/admin/service/AdminMarketingService.java
+++ b/src/main/java/com/bookbla/americano/domain/admin/service/AdminMarketingService.java
@@ -7,9 +7,9 @@ import com.bookbla.americano.domain.member.repository.MemberPushAlarmRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberPushAlarm;
+import com.bookbla.americano.domain.notification.controller.dto.request.PushAlarmAllCreateRequest;
+import com.bookbla.americano.domain.notification.service.AlarmService;
 import com.bookbla.americano.domain.notification.service.NotificationClient;
-import com.bookbla.americano.domain.notification.service.PostcardPushAlarmEventListener;
-import com.bookbla.americano.domain.notification.service.PushAlarmSendAllEvent;
 import com.bookbla.americano.domain.notification.service.dto.NotificationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,7 +24,7 @@ public class AdminMarketingService {
     private final MemberRepository memberRepository;
     private final MemberPushAlarmRepository memberPushAlarmRepository;
     private final TransactionTemplate transactionTemplate;
-    private final PostcardPushAlarmEventListener postcardPushAlarmEventListener;
+    private final AlarmService alarmService;
 
     public List<NotificationResponse> sendNotification(NotificationDto notificationDto, Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
@@ -46,7 +46,7 @@ public class AdminMarketingService {
     }
 
     public void sendNotifications(NotificationDto dto) {
-        postcardPushAlarmEventListener.sendAll(new PushAlarmSendAllEvent(dto.getTitle(), dto.getContents()));
+        alarmService.sendPushAlarmAll(new PushAlarmAllCreateRequest(dto.getTitle(), dto.getContents()));
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/notification/service/AlarmService.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/service/AlarmService.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-class AlarmService {
+public class AlarmService {
 
     private static final String POSTCARD_SEND_TITLE = "띵동~\uD83D\uDC8C 엽서가 도착했어요!";
     private static final String POSTCARD_SEND_BODY = "%s님이 엽서를 보냈어요! 지금 확인해 보세요~\uD83E\uDD70";
@@ -45,7 +45,7 @@ class AlarmService {
     public void sendPushAlarmForReceivePostCard(Member sendMember, Member receiveMember) {
         // 해당 멤버가 푸시 토큰이 없다면 에러 발생
         if (receiveMember.getPushToken() == null) {
-            throw new BaseException(PushAlarmExceptionType.NOT_FOUND_TOKEN);
+            return;
         }
 
         // 해당 멤버가 회원가입 완료상태가 아니라면
@@ -70,7 +70,7 @@ class AlarmService {
     public void sendPushAlarmForAcceptPostcard(Member sendMember, Member receiveMember) {
         // 해당 멤버가 푸시 토큰이 없다면 에러 발생
         if (sendMember.getPushToken() == null) {
-            throw new BaseException(PushAlarmExceptionType.NOT_FOUND_TOKEN);
+            return;
         }
 
         // 해당 멤버가 회원가입 완료상태가 아니면서 매칭 비활성화가 아니라면

--- a/src/main/java/com/bookbla/americano/domain/notification/service/AlarmService.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/service/AlarmService.java
@@ -25,11 +25,12 @@ import io.github.jav.exposerversdk.PushClient;
 import io.github.jav.exposerversdk.PushClientException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class AlarmService {
+class AlarmService {
 
     private static final String POSTCARD_SEND_TITLE = "띵동~\uD83D\uDC8C 엽서가 도착했어요!";
     private static final String POSTCARD_SEND_BODY = "%s님이 엽서를 보냈어요! 지금 확인해 보세요~\uD83E\uDD70";
@@ -40,7 +41,7 @@ public class AlarmService {
     private final MemberPushAlarmRepository memberPushAlarmRepository;
     private final PushAlarmLogRepository pushAlarmLogRepository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void sendPushAlarmForReceivePostCard(Member sendMember, Member receiveMember) {
         // 해당 멤버가 푸시 토큰이 없다면 에러 발생
         if (receiveMember.getPushToken() == null) {
@@ -65,7 +66,7 @@ public class AlarmService {
         memberPushAlarmRepository.save(memberPushAlarm);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void sendPushAlarmForAcceptPostcard(Member sendMember, Member receiveMember) {
         // 해당 멤버가 푸시 토큰이 없다면 에러 발생
         if (sendMember.getPushToken() == null) {

--- a/src/main/java/com/bookbla/americano/domain/notification/service/PostcardAlarmEvent.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/service/PostcardAlarmEvent.java
@@ -1,0 +1,14 @@
+package com.bookbla.americano.domain.notification.service;
+
+import com.bookbla.americano.domain.member.repository.entity.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class PostcardAlarmEvent {
+
+    private final Member sendMember;
+    private final Member receiveMember;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/notification/service/PostcardPushAlarmEventListener.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/service/PostcardPushAlarmEventListener.java
@@ -1,0 +1,34 @@
+package com.bookbla.americano.domain.notification.service;
+
+import com.bookbla.americano.domain.notification.controller.dto.request.PushAlarmAllCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class PostcardPushAlarmEventListener {
+
+    private final AlarmService alarmService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void sendPostcard(PostcardAlarmEvent postcardAlarmEvent) {
+        alarmService.sendPushAlarmForReceivePostCard(postcardAlarmEvent.getSendMember(), postcardAlarmEvent.getReceiveMember());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void acceptPostcard(PostcardAlarmEvent postcardAlarmEvent) {
+        alarmService.sendPushAlarmForAcceptPostcard(postcardAlarmEvent.getSendMember(), postcardAlarmEvent.getReceiveMember());
+    }
+
+    @EventListener
+    @Async
+    public void sendAll(PushAlarmSendAllEvent event) {
+        alarmService.sendPushAlarmAll(new PushAlarmAllCreateRequest(event.getTitle(), event.getContents()));
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/notification/service/PostcardPushAlarmEventListener.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/service/PostcardPushAlarmEventListener.java
@@ -1,8 +1,6 @@
 package com.bookbla.americano.domain.notification.service;
 
-import com.bookbla.americano.domain.notification.controller.dto.request.PushAlarmAllCreateRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -24,11 +22,5 @@ public class PostcardPushAlarmEventListener {
     @Async
     public void acceptPostcard(PostcardAlarmEvent postcardAlarmEvent) {
         alarmService.sendPushAlarmForAcceptPostcard(postcardAlarmEvent.getSendMember(), postcardAlarmEvent.getReceiveMember());
-    }
-
-    @EventListener
-    @Async
-    public void sendAll(PushAlarmSendAllEvent event) {
-        alarmService.sendPushAlarmAll(new PushAlarmAllCreateRequest(event.getTitle(), event.getContents()));
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/notification/service/PushAlarmSendAllEvent.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/service/PushAlarmSendAllEvent.java
@@ -1,0 +1,13 @@
+package com.bookbla.americano.domain.notification.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class PushAlarmSendAllEvent {
+
+    private final String title;
+    private final String contents;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -1,6 +1,10 @@
 package com.bookbla.americano.domain.postcard.service;
 
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.exception.MemberExceptionType;
@@ -17,7 +21,8 @@ import com.bookbla.americano.domain.memberask.repository.MemberAskRepository;
 import com.bookbla.americano.domain.memberask.repository.MemberReplyRepository;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberAsk;
 import com.bookbla.americano.domain.memberask.repository.entity.MemberReply;
-import com.bookbla.americano.domain.notification.service.AlarmService;
+import com.bookbla.americano.domain.notification.service.PostcardAlarmEvent;
+import com.bookbla.americano.domain.notification.service.PostcardPushAlarmEventListener;
 import com.bookbla.americano.domain.postcard.controller.dto.response.ContactInfoResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
@@ -42,10 +47,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -62,45 +63,47 @@ public class PostcardService {
     private final MemberBookRepository memberBookRepository;
     private final MemberBlockRepository memberBlockRepository;
     private final MemberBookService memberBookService;
-    private final AlarmService alarmService;
+    private final PostcardPushAlarmEventListener postcardPushAlarmEventListener;
 
     public SendPostcardResponse send(Long memberId, SendPostcardRequest request) {
         MemberPostcard memberPostcard = memberPostcardRepository.findMemberPostcardByMemberId(
-                memberId)
-            .orElseThrow(
-                () -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
+                        memberId)
+                .orElseThrow(
+                        () -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
         memberPostcard.validate();
 
         memberBlockRepository.findByBlockerMemberIdAndBlockedMemberId(request.getReceiveMemberId(), memberId)
-                .ifPresent(it -> { throw new BaseException(PostcardExceptionType.BLOCKED); });
+                .ifPresent(it -> {
+                    throw new BaseException(PostcardExceptionType.BLOCKED);
+                });
         List<Postcard> sentPostcards = postcardRepository.findBySendMemberIdAndReceiveMemberId(
-            memberId, request.getReceiveMemberId());
+                memberId, request.getReceiveMemberId());
         sentPostcards.forEach(Postcard::validateSendPostcard);
 
         Member member = memberRepository.getByIdOrThrow(memberId);
         Member targetMember = memberRepository.getByIdOrThrow(request.getReceiveMemberId());
 
         MemberAsk memberAsk = memberAskRepository.findByMember(member)
-            .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
+                .orElseThrow(() -> new BaseException(MemberAskExceptionType.NOT_REGISTERED_MEMBER));
         MemberReply memberReply = MemberReply.builder()
-            .memberAsk(memberAsk)
-            .content(request.getMemberReply())
-            .build();
+                .memberAsk(memberAsk)
+                .content(request.getMemberReply())
+                .build();
         memberReplyRepository.save(memberReply);
 
         List<QuizReply> correctReplies = new ArrayList<>();
         boolean isCorrect = false;
         for (SendPostcardRequest.QuizAnswer quizAnswer : request.getQuizAnswerList()) {
             QuizQuestion quizQuestion = quizQuestionRepository.getByIdOrThrow(
-                quizAnswer.getQuizId());
+                    quizAnswer.getQuizId());
             CorrectStatus status = quizQuestion.solve(quizAnswer.getQuizAnswer());
 
             QuizReply quizReply = QuizReply.builder()
-                .quizQuestion(quizQuestion)
-                .answer(quizAnswer.getQuizAnswer())
-                .member(member)
-                .correctStatus(status)
-                .build();
+                    .quizQuestion(quizQuestion)
+                    .answer(quizAnswer.getQuizAnswer())
+                    .member(member)
+                    .correctStatus(status)
+                    .build();
             correctReplies.add(quizReply);
 
             if (status == CorrectStatus.CORRECT) {
@@ -113,15 +116,15 @@ public class PostcardService {
         memberPostcard.use();
 
         PostcardType postCardType = postcardTypeRepository.getByIdOrThrow(
-            request.getPostcardTypeId());
+                request.getPostcardTypeId());
         Postcard postcard = Postcard.builder()
-            .sendMember(member)
-            .receiveMember(targetMember)
-            .postcardStatus(status)
-            .memberReply(memberReply)
-            .postcardType(postCardType)
-            .imageUrl(postCardType.getImageUrl())
-            .build();
+                .sendMember(member)
+                .receiveMember(targetMember)
+                .postcardStatus(status)
+                .memberReply(memberReply)
+                .postcardType(postCardType)
+                .imageUrl(postCardType.getImageUrl())
+                .build();
         postcardRepository.save(postcard);
 
         for (QuizReply quizReply : correctReplies) {
@@ -130,7 +133,7 @@ public class PostcardService {
         }
 
         // 엽서를 받는 멤버에게 푸시 알림
-        alarmService.sendPushAlarmForReceivePostCard(member, targetMember);
+        postcardPushAlarmEventListener.sendPostcard(new PostcardAlarmEvent(member, targetMember));
 
         return SendPostcardResponse.builder().isSendSuccess(isCorrect).build();
     }
@@ -143,18 +146,18 @@ public class PostcardService {
     // 보낸 엽서
     public List<MemberPostcardFromResponse> getPostcardsFromMember(Long memberId) {
         List<PostcardFromResponse> postcardFromResponseList = postcardRepository.getPostcardsFromMember(
-            memberId);
+                memberId);
         List<MemberPostcardFromResponse> memberPostcardFromResponseList = new ArrayList<>();
 
         for (PostcardFromResponse i : postcardFromResponseList) {
             MemberPostcardFromResponse nowResponse;
             MemberBookReadResponses memberBookList = memberBookService.readMemberBooks(
-                i.getMemberId());
+                    i.getMemberId());
             List<String> nowBookImageUrls = new ArrayList<>();
             nowResponse = new MemberPostcardFromResponse(i.getMemberId(), i.getMemberName(),
-                i.getMemberBirthDate(), i.getMemberGender(), i.getMemberSchoolName(),
-                i.getMemberProfileImageUrl(),
-                i.getMemberOpenKakaoRoomUrl(), i.getPostcardId(), i.getPostcardStatus());
+                    i.getMemberBirthDate(), i.getMemberGender(), i.getMemberSchoolName(),
+                    i.getMemberProfileImageUrl(),
+                    i.getMemberOpenKakaoRoomUrl(), i.getPostcardId(), i.getPostcardStatus());
             for (MemberBookReadResponses.MemberBookReadResponse j : memberBookList.getMemberBookReadResponses()) {
                 if (j.isRepresentative()) {
                     nowResponse.setRepresentativeBookTitle(j.getTitle());
@@ -174,7 +177,7 @@ public class PostcardService {
     // 받은 엽서
     public List<MemberPostcardToResponse> getPostcardsToMember(Long memberId) {
         List<PostcardToResponse> postcardToResponseList = postcardRepository.getPostcardsToMember(
-            memberId);
+                memberId);
         List<MemberPostcardToResponse> memberPostcardToResponseList = new ArrayList<>();
         long now = -1;
         MemberPostcardToResponse nowResponse = new MemberPostcardToResponse();
@@ -195,12 +198,12 @@ public class PostcardService {
                 // 초기화
                 now = i.getMemberId();
                 nowResponse = new MemberPostcardToResponse(i.getPostcardId(), i.getMemberId(),
-                    i.getMemberName(), i.getMemberProfileImageUrl(), i.getMemberBirthDate(),
-                    i.getMemberGender(),
-                    i.getDrinkType(), i.getSmokeType(), i.getContactType(), i.getDateStyleType(),
-                    i.getDateCostType(), i.getMbti(), i.getJustFriendType(),
-                    i.getMemberSchoolName(), i.getMemberReplyContent(), i.getPostcardStatus(),
-                    i.getPostcardImageUrl(), i.getMemberKakaoRoomUrl());
+                        i.getMemberName(), i.getMemberProfileImageUrl(), i.getMemberBirthDate(),
+                        i.getMemberGender(),
+                        i.getDrinkType(), i.getSmokeType(), i.getContactType(), i.getDateStyleType(),
+                        i.getDateCostType(), i.getMbti(), i.getJustFriendType(),
+                        i.getMemberSchoolName(), i.getMemberReplyContent(), i.getPostcardStatus(),
+                        i.getPostcardImageUrl(), i.getMemberKakaoRoomUrl());
                 nowBookTitles = new ArrayList<>();
                 nowBookImageUrls = new ArrayList<>();
                 nowCorrectStatuses = new ArrayList<>();
@@ -237,7 +240,7 @@ public class PostcardService {
 
     public void readMemberPostcard(Long memberId, Long postcardId) {
         Postcard postcard = postcardRepository.findById(postcardId)
-            .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
         if (!Objects.equals(postcard.getReceiveMember().getId(), memberId)) {
             throw new BaseException(PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD);
         } else if (!postcard.getPostcardStatus().equals(PostcardStatus.PENDING)) {
@@ -248,16 +251,16 @@ public class PostcardService {
             }
         }
         MemberPostcard memberPostcard = memberPostcardRepository.findMemberPostcardByMemberId(
-                memberId)
-            .orElseThrow(
-                () -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
+                        memberId)
+                .orElseThrow(
+                        () -> new BaseException(MemberExceptionType.EMPTY_MEMBER_POSTCARD_INFO));
         memberPostcard.use();
         updatePostcardStatus(memberId, postcardId, PostcardStatus.READ);
     }
 
     public PostcardStatus getPostcardStatus(Long postcardId) {
         Postcard postcard = postcardRepository.findById(postcardId)
-            .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
 
         return postcard.getPostcardStatus();
     }
@@ -265,10 +268,10 @@ public class PostcardService {
     public void updatePostcardStatus(Long memberId, Long postcardId,
                                      PostcardStatus postcardStatus) {
         Postcard postcard = postcardRepository.findById(postcardId)
-            .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
         Member member = memberRepository.getByIdOrThrow(memberId);
         if (!member.equals(postcard.getSendMember()) && !member.equals(
-            postcard.getReceiveMember())) {
+                postcard.getReceiveMember())) {
             throw new BaseException(PostcardExceptionType.ACCESS_DENIED_TO_POSTCARD);
         }
 
@@ -278,16 +281,16 @@ public class PostcardService {
         if (postcardStatus.isAccept()) {
             Member sendMember = postcard.getSendMember();
             Member receiveMember = postcard.getReceiveMember();
-            alarmService.sendPushAlarmForAcceptPostcard(sendMember, receiveMember);
+            postcardPushAlarmEventListener.acceptPostcard(new PostcardAlarmEvent(sendMember, receiveMember));
         }
     }
 
     @Transactional(readOnly = true)
     public PostcardSendValidateResponse validateSendPostcard(Long sendMemberId, Long targetMemberId) {
         memberBlockRepository.findByBlockerMemberIdAndBlockedMemberId(targetMemberId, sendMemberId)
-                .ifPresent(it -> { throw new BaseException(PostcardExceptionType.BLOCKED); });
+                .ifPresent(it -> {throw new BaseException(PostcardExceptionType.BLOCKED);});
         List<Postcard> sendPostcards = postcardRepository.findBySendMemberIdAndReceiveMemberId(
-            sendMemberId, targetMemberId);
+                sendMemberId, targetMemberId);
         sendPostcards.forEach(Postcard::validateSendPostcard);
 
         boolean isRefused = sendPostcards.stream().anyMatch(Postcard::isRefused);


### PR DESCRIPTION
## 📄 Summary

> 엽서 전송/수락과 알림 발송이 한 트랜잭션 안에 묶여있어서
사용자 알림 발송이 실패했을시, 엽서 수락/전송이 아예 불가능하도록 되어있습니다

이에 트랜잭션도 분리하였고, 아예 다른 관심사인 것 같아서 이벤트로 받게 해놨어요
비동기도 붙여놨는데, 스레드 풀 설정은 추후에 해두려 합니당

## 🙋🏻 More

>