### PR TITLE
feat: 축제에서 사용할 이벤트 초대코드 기능 구현

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBookmark.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBookmark.java
@@ -47,7 +47,7 @@ public class MemberBookmark extends BaseEntity {
     }
 
     public void addInvitationBookmark() {
-        bookmarkCount += 150;
+        bookmarkCount += 70;
     }
 
     public void addBookmark(int count) {

--- a/src/main/java/com/bookbla/americano/domain/school/controller/dto/response/InvitationResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/school/controller/dto/response/InvitationResponse.java
@@ -15,4 +15,8 @@ public class InvitationResponse {
                 invitingMember.getMemberProfile().getGenderName()
         );
     }
+
+    public static InvitationResponse createFestivalTemporaryInvitationCode() {
+        return new InvitationResponse("축제 임시 코드입니다");
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/school/event/InvitationEventListener.java
+++ b/src/main/java/com/bookbla/americano/domain/school/event/InvitationEventListener.java
@@ -1,7 +1,5 @@
 package com.bookbla.americano.domain.school.event;
 
-import java.util.Optional;
-
 import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
@@ -31,6 +29,11 @@ public class InvitationEventListener {
     }
 
     private void processInvitation(Invitation invitation, MemberBookmark invitedMemberBookmark) {
+        if (invitation.isFestivalTemporaryInvitation()) {
+            invitedMemberBookmark.addBookmark(105);
+            return;
+        }
+
         Member invitedMember = memberRepository.getByIdOrThrow(invitation.getInvitedMemberId());
         if (invitedMember.isWoman()) {
             handleWomanInvitation(invitation, invitedMemberBookmark);

--- a/src/main/java/com/bookbla/americano/domain/school/repository/entity/Invitation.java
+++ b/src/main/java/com/bookbla/americano/domain/school/repository/entity/Invitation.java
@@ -22,6 +22,8 @@ import static com.bookbla.americano.domain.school.repository.entity.InvitationSt
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Invitation extends BaseEntity {
 
+    public static final long FESTIVAL_TEMPORARY_INVITING_MEMBER_ID = 0L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,6 +42,10 @@ public class Invitation extends BaseEntity {
 
     public void complete() {
         this.invitationStatus = COMPLETED;
+    }
+
+    public boolean isFestivalTemporaryInvitation() {
+        return FESTIVAL_TEMPORARY_INVITING_MEMBER_ID == invitingMemberId;
     }
 }
 

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -36,10 +36,10 @@ public class InvitationService {
         return MemberInvitationResponse.from(member);
     }
 
-    public InvitationResponse entryInvitationCode(Long memberId, InvitationCodeEntryRequest request) {
+    public InvitationResponse entryInvitationCode(Long invitedMemberId, InvitationCodeEntryRequest request) {
         if (isFestivalInvitationCode(request.getInvitationCode())) {
             invitationRepository.save(Invitation.builder()
-                    .invitedMemberId(memberId)
+                    .invitedMemberId(invitedMemberId)
                     .invitingMemberId(FESTIVAL_TEMPORARY_INVITING_MEMBER_ID)
                     .build());
             return InvitationResponse.createFestivalTemporaryInvitationCode();
@@ -48,8 +48,8 @@ public class InvitationService {
         Member invitingMember = memberRepository.findByInvitationCode(request.getInvitationCode())
                 .orElseThrow(() -> new BaseException(MemberExceptionType.INVITATION_CODE_NOT_FOUND));
 
-        invitationRepository.findByInvitedMemberId(memberId)
-                .orElseGet(() -> invite(memberId, invitingMember));
+        invitationRepository.findByInvitedMemberId(invitedMemberId)
+                .orElseGet(() -> invite(invitedMemberId, invitingMember));
 
         return InvitationResponse.from(invitingMember);
     }

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -37,7 +37,7 @@ public class InvitationService {
     }
 
     public InvitationResponse entryInvitationCode(Long invitedMemberId, InvitationCodeEntryRequest request) {
-        if (isFestivalInvitationCode(request.getInvitationCode())) {
+        if (isFestivalTemporaryInvitationCode(request.getInvitationCode())) {
             invitationRepository.save(Invitation.builder()
                     .invitedMemberId(invitedMemberId)
                     .invitingMemberId(FESTIVAL_TEMPORARY_INVITING_MEMBER_ID)
@@ -54,7 +54,7 @@ public class InvitationService {
         return InvitationResponse.from(invitingMember);
     }
 
-    private boolean isFestivalInvitationCode(String invitationCode) {
+    private boolean isFestivalTemporaryInvitationCode(String invitationCode) {
         return FESTIVAL_TEMPORARY_INVITATION_CODE.equals(invitationCode);
     }
 

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -1,11 +1,11 @@
 package com.bookbla.americano.domain.school.service;
 
 import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.school.controller.dto.request.InvitationCodeEntryRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberInvitationResponse;
 import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.Member;
+import com.bookbla.americano.domain.school.controller.dto.request.InvitationCodeEntryRequest;
 import com.bookbla.americano.domain.school.controller.dto.response.InvitationResponse;
 import com.bookbla.americano.domain.school.repository.InvitationRepository;
 import com.bookbla.americano.domain.school.repository.entity.Invitation;
@@ -13,10 +13,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.bookbla.americano.domain.school.repository.entity.Invitation.FESTIVAL_TEMPORARY_INVITING_MEMBER_ID;
+
+
+/*
+* 8. 15 도현님 요청
+* 축제용 임시 초대코드 발급
+* */
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class InvitationService {
+
+    private static final String FESTIVAL_TEMPORARY_INVITATION_CODE = "JUST4YOU";
 
     private final MemberRepository memberRepository;
     private final InvitationRepository invitationRepository;
@@ -28,6 +37,14 @@ public class InvitationService {
     }
 
     public InvitationResponse entryInvitationCode(Long memberId, InvitationCodeEntryRequest request) {
+        if (isFestivalInvitationCode(request.getInvitationCode())) {
+            invitationRepository.save(Invitation.builder()
+                    .invitedMemberId(memberId)
+                    .invitingMemberId(FESTIVAL_TEMPORARY_INVITING_MEMBER_ID)
+                    .build());
+            return InvitationResponse.createFestivalTemporaryInvitationCode();
+        }
+
         Member invitingMember = memberRepository.findByInvitationCode(request.getInvitationCode())
                 .orElseThrow(() -> new BaseException(MemberExceptionType.INVITATION_CODE_NOT_FOUND));
 
@@ -35,6 +52,10 @@ public class InvitationService {
                 .orElseGet(() -> invite(memberId, invitingMember));
 
         return InvitationResponse.from(invitingMember);
+    }
+
+    private boolean isFestivalInvitationCode(String invitationCode) {
+        return FESTIVAL_TEMPORARY_INVITATION_CODE.equalsIgnoreCase(invitationCode);
     }
 
     private Invitation invite(Long invitedMemberId, Member invitingMember) {

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -55,7 +55,7 @@ public class InvitationService {
     }
 
     private boolean isFestivalInvitationCode(String invitationCode) {
-        return FESTIVAL_TEMPORARY_INVITATION_CODE.equalsIgnoreCase(invitationCode);
+        return FESTIVAL_TEMPORARY_INVITATION_CODE.equals(invitationCode);
     }
 
     private Invitation invite(Long invitedMemberId, Member invitingMember) {


### PR DESCRIPTION
## 📄 Summary

> 학교 축제에서 사용할 임시축제초대코드를 발급하는 기능을 구현하였습니다(도현님 요청)

기능 설명
- 축제때 하실 이벤트를 위한 임시 기능입니다
- 이 초대코드를 입력하면 책갈피 105개 지급합니당

## 🙋🏻 More

> 여성회원 초대코드 입력시 책갈피 발급 정책이 변경돼서, 해당 내역도 반영해놨습니다