### PR TITLE
feat: 받은 엽서/보낸엽서 조회api 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBookmark.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBookmark.java
@@ -3,6 +3,12 @@ package com.bookbla.americano.domain.member.repository.entity;
 import com.bookbla.americano.base.entity.BaseEntity;
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.exception.MemberBookmarkExceptionType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -10,11 +16,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -44,8 +45,19 @@ public class MemberBookmark extends BaseEntity {
         bookmarkCount = bookmarkCount - 35;
     }
 
+    public void readPostcard() {
+        validateReadPostcard();
+        bookmarkCount = bookmarkCount - 5;
+    }
+
     public void validateSendPostcard() {
         if (bookmarkCount < 35) {
+            throw new BaseException(MemberBookmarkExceptionType.INVALID_BOOKMARK_COUNTS);
+        }
+    }
+
+    public void validateReadPostcard() {
+        if (bookmarkCount < 5) {
             throw new BaseException(MemberBookmarkExceptionType.INVALID_BOOKMARK_COUNTS);
         }
     }

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -6,6 +6,7 @@ import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardSend
 import com.bookbla.americano.domain.postcard.controller.dto.request.PostcardStatusUpdateRequest;
 import com.bookbla.americano.domain.postcard.controller.dto.response.ContactInfoResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardStatusResponse;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
@@ -39,6 +40,13 @@ public class PostcardController {
     public ResponseEntity<List<MemberPostcardFromResponse>> readPostcardsFromMember(
             @Parameter(hidden = true) @User LoginUser loginUser) {
         return ResponseEntity.ok(postcardService.getPostcardsFromMember(loginUser.getMemberId()));
+    }
+
+    @Operation(summary = "받은 엽서 조회", description = "사용자가 받은 엽서 조회")
+    @GetMapping("/to")
+    public ResponseEntity<List<MemberPostcardToResponse>> readPostcardsToMember(
+            @Parameter(hidden = true) @User LoginUser loginUser) {
+        return ResponseEntity.ok(postcardService.getPostcardsToMember(loginUser.getMemberId()));
     }
 
     @Operation(summary = "엽서 읽기", description = "받은 엽서 조회를 위한 엽서 사용 및 엽서 상태 (READ)로 변경")

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardToResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/MemberPostcardToResponse.java
@@ -1,0 +1,77 @@
+package com.bookbla.americano.domain.postcard.controller.dto.response;
+
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+// 받은 엽서
+public class MemberPostcardToResponse {
+
+    private long postcardId;
+
+    private long memberId;
+
+    private String memberName;
+
+    private String memberProfileImageUrl;
+
+    private int memberAge;
+
+    private String memberGender;
+
+    private String drinkType;
+
+    private String smokeType;
+
+    private String contactType;
+
+    private String dateStyleType;
+
+    private String dateCostType;
+
+    private String mbti;
+
+    private String justFriendType;
+
+    private String heightType;
+
+    private String memberSchoolName;
+
+    private LocalDateTime receivedTime;
+
+    private PostcardStatus postcardStatus;
+
+    private String postcardImageUrl;
+
+    public MemberPostcardToResponse(PostcardToResponse i) {
+
+        this.postcardId = i.getPostcardId();
+        this.memberId = i.getMemberId();
+        this.memberName = i.getMemberName();
+        this.memberProfileImageUrl = i.getMemberProfileImageUrl();
+        this.memberAge = getAge(i.getMemberBirthDate());
+        this.memberGender = i.getMemberGender().name();
+        this.smokeType = i.getSmokeType().getDetailValue();
+        this.mbti = i.getMbti().name();
+        this.memberSchoolName = i.getMemberSchoolName();
+        this.receivedTime = i.getReceivedTime();
+        this.postcardStatus = i.getPostcardStatus();
+        this.postcardImageUrl = i.getPostcardImageUrl();
+    }
+
+    private int getAge(LocalDate birthDay) {
+        return LocalDate.now().getYear() - birthDay.getYear() + 1;
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/PostcardRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/PostcardRepositoryCustom.java
@@ -1,6 +1,8 @@
 package com.bookbla.americano.domain.postcard.repository.custom;
 
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
 
 import java.util.List;
 
@@ -8,4 +10,7 @@ public interface PostcardRepositoryCustom {
 
     List<PostcardFromResponse> getPostcardsFromMember(Long memberId);
 
+    List<PostcardToResponse> getPostcardsToMember(Long memberId);
+
+    List<Postcard> refuseExpiredPostcard();
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -1,15 +1,20 @@
 package com.bookbla.americano.domain.postcard.repository.custom.impl;
 
-import java.util.List;
-
 import com.bookbla.americano.domain.member.repository.entity.QMember;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.repository.custom.PostcardRepositoryCustom;
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
 import com.bookbla.americano.domain.postcard.repository.entity.QPostcard;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.bookbla.americano.domain.school.repository.entity.QSchool.school;
 
@@ -39,6 +44,49 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                 .innerJoin(school).on(member.school.eq(school))
                 .where(postcard.sendMember.id.eq(memberId))
                 .orderBy(postcard.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<PostcardToResponse> getPostcardsToMember(Long memberId) {
+        QMember member = QMember.member;
+        QPostcard postcard = QPostcard.postcard;
+
+        return queryFactory.select(Projections.fields(PostcardToResponse.class
+                        , postcard.id.as("postcardId")
+                        , postcard.sendMember.id.as("memberId")
+                        , postcard.sendMember.memberProfile.name.as("memberName")
+                        , postcard.sendMember.memberProfile.birthDate.as("memberBirthDate")
+                        , postcard.sendMember.memberProfile.gender.as("memberGender")
+                        , member.school.name.as("memberSchoolName")
+                        , member.memberStyle.profileImageType.imageUrl.as("memberProfileImageUrl")
+                        , postcard.sendMember.memberStyle.smokeType
+                        , postcard.sendMember.memberStyle.mbti
+                        , postcard.createdAt.as("receivedTime")
+                        , postcard.postcardStatus
+                        , postcard.postcardType.imageUrl.as("postcardImageUrl"))
+                )
+                .from(member)
+                .innerJoin(postcard).on(member.eq(postcard.sendMember))
+                .where(postcard.receiveMember.id.eq(memberId)
+                        .and(postcard.postcardStatus.eq(PostcardStatus.PENDING)
+                                .or(postcard.postcardStatus.eq(PostcardStatus.READ))
+                                .or(postcard.postcardStatus.eq(PostcardStatus.ACCEPT))))
+                .orderBy(postcard.sendMember.id.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<Postcard> refuseExpiredPostcard() {
+        QPostcard postcard = QPostcard.postcard;
+
+        LocalDate now = LocalDate.now();
+        LocalDateTime expireDate = now.minusDays(2).atStartOfDay();
+
+        return queryFactory.selectFrom(postcard)
+                .where(postcard.createdAt.before(expireDate)
+                        .and(postcard.postcardStatus.eq(PostcardStatus.PENDING)
+                                .or(postcard.postcardStatus.eq(PostcardStatus.READ))))
                 .fetch();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -16,8 +16,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.bookbla.americano.domain.school.repository.entity.QSchool.school;
-
 @Repository
 @RequiredArgsConstructor
 public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
@@ -35,13 +33,12 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                         , postcard.receiveMember.memberProfile.birthDate.as("memberBirthDate")
                         , postcard.receiveMember.memberProfile.gender.as("memberGender")
                         , member.school.name.as("memberSchoolName")
-                        , postcard.receiveMember.memberStyle.profileImageType.imageUrl.as("memberProfileImageUrl")
+                        , member.memberStyle.profileImageType.imageUrl.as("memberProfileImageUrl")
                         , postcard.id.as("postcardId")
                         , postcard.postcardStatus.as("postcardStatus"))
                 )
-                .from(postcard)
-                .innerJoin(member).on(postcard.receiveMember.eq(member))
-                .innerJoin(school).on(member.school.eq(school))
+                .from(member)
+                .innerJoin(postcard).on(member.eq(postcard.receiveMember))
                 .where(postcard.sendMember.id.eq(memberId))
                 .orderBy(postcard.createdAt.desc())
                 .fetch();
@@ -72,7 +69,7 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                         .and(postcard.postcardStatus.eq(PostcardStatus.PENDING)
                                 .or(postcard.postcardStatus.eq(PostcardStatus.READ))
                                 .or(postcard.postcardStatus.eq(PostcardStatus.ACCEPT))))
-                .orderBy(postcard.sendMember.id.asc())
+                .orderBy(postcard.createdAt.desc())
                 .fetch();
     }
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -34,7 +34,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -124,12 +123,8 @@ public class PostcardService {
         List<PostcardToResponse> postcardToResponseList = postcardRepository.getPostcardsToMember(
                 memberId);
 
-        List<MemberPostcardToResponse> memberPostcardToResponseList = postcardToResponseList.stream()
+        return postcardToResponseList.stream()
                 .map(MemberPostcardToResponse::new)
-                .collect(Collectors.toList());
-
-        return memberPostcardToResponseList.stream()
-                .sorted(Comparator.comparing(MemberPostcardToResponse::getReceivedTime).reversed())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -16,6 +16,7 @@ import com.bookbla.americano.domain.notification.event.PostcardAlarmEvent;
 import com.bookbla.americano.domain.notification.event.PushAlarmEventHandler;
 import com.bookbla.americano.domain.postcard.controller.dto.response.ContactInfoResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardFromResponse;
+import com.bookbla.americano.domain.postcard.controller.dto.response.MemberPostcardToResponse;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
@@ -25,6 +26,7 @@ import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
 import com.bookbla.americano.domain.postcard.repository.entity.PostcardType;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
+import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardTypeResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +34,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -115,6 +119,20 @@ public class PostcardService {
         return memberPostcardFromResponseList;
     }
 
+    // 받은 엽서
+    public List<MemberPostcardToResponse> getPostcardsToMember(Long memberId) {
+        List<PostcardToResponse> postcardToResponseList = postcardRepository.getPostcardsToMember(
+                memberId);
+
+        List<MemberPostcardToResponse> memberPostcardToResponseList = postcardToResponseList.stream()
+                .map(MemberPostcardToResponse::new)
+                .collect(Collectors.toList());
+
+        return memberPostcardToResponseList.stream()
+                .sorted(Comparator.comparing(MemberPostcardToResponse::getReceivedTime).reversed())
+                .collect(Collectors.toList());
+    }
+
     public void readMemberPostcard(Long memberId, Long postcardId) {
         Postcard postcard = postcardRepository.findById(postcardId)
                 .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
@@ -131,7 +149,7 @@ public class PostcardService {
                         memberId)
                 .orElseThrow(
                         () -> new BaseException(MemberExceptionType.EMPTY_MEMBER_BOOKMARK_INFO));
-        memberBookmark.sendPostcard();
+        memberBookmark.readPostcard();
         updatePostcardStatus(memberId, postcardId, PostcardStatus.READ);
     }
 
@@ -159,6 +177,12 @@ public class PostcardService {
             Member sendMember = postcard.getSendMember();
             Member receiveMember = postcard.getReceiveMember();
             postcardPushAlarmEventListener.acceptPostcard(new PostcardAlarmEvent(sendMember, receiveMember));
+        } else if (postcardStatus.isRefused()) { // 거절 시 환불
+            MemberBookmark memberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(
+                            postcard.getSendMember().getId())
+                    .orElseThrow(
+                            () -> new BaseException(MemberExceptionType.EMPTY_MEMBER_BOOKMARK_INFO));
+            memberBookmark.addBookmark(35);
         }
     }
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/PostcardToResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/PostcardToResponse.java
@@ -1,0 +1,52 @@
+package com.bookbla.americano.domain.postcard.service.dto.response;
+
+import com.bookbla.americano.domain.member.enums.Gender;
+import com.bookbla.americano.domain.member.enums.Mbti;
+import com.bookbla.americano.domain.member.enums.SmokeType;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+// 받은 엽서
+public class PostcardToResponse {
+
+    private long postcardId;
+
+    // Member 정보
+    private long memberId;
+
+    private String memberName;
+
+    private LocalDate memberBirthDate;
+
+    private Gender memberGender;
+
+    private String memberSchoolName;
+
+    private String memberProfileImageUrl;
+
+    private SmokeType smokeType;
+
+    private Mbti mbti;
+
+    // 엽서 받은 시간
+    private LocalDateTime receivedTime;
+
+    // 엽서 상태
+    private PostcardStatus postcardStatus;
+
+    // 엽서 이미지
+    private String postcardImageUrl;
+
+}

--- a/src/main/java/com/bookbla/americano/scheduler/ScheduleWorker.java
+++ b/src/main/java/com/bookbla/americano/scheduler/ScheduleWorker.java
@@ -114,7 +114,6 @@ class ScheduleWorker {
     public void refuseExpiredPostcardSchedule() {
         try {
             List<Postcard> refusedPostcards = postcardRepository.refuseExpiredPostcard();
-            // TODO 환불 로직 확인
             for (Postcard i : refusedPostcards) {
                 postcardRepository.updatePostcardStatus(PostcardStatus.REFUSED, i.getId());
                 MemberBookmark memberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(


### PR DESCRIPTION
## 📄 Summary

>### 받은 엽서 조회(/postcard/to) api 수정
>- 한국 나이로 나이 변경
>- 엽서 읽기(READ) 시 책갈피 5개 사용으로 수정
>- 엽서 거절로 상태 변경 시 35개 환불
>- 엽서를 받은 날짜 포함 3일이 지나면 엽서 거절로 상태 변경 및 보낸 사람에게 책갈피 환불
>    - 만약, 9/8에 보낸 엽서 중 PENDING/READ 상태에 있는 엽서 들은 9/11일 0시 0분에 모두 거절 됨
>- 받은 엽서 조회(/postcard/to) api에서 전달하는 데이터 수정(책 관련 데이터 모두 보내지 않도록 수정.)
>    - 엽서 ID
>    - 보낸 사람 Id, 닉네임, 프로필 이미지, 나이, 성별, 스타일 정보, 학교 이름
>    - 엽서를 받은 시간, 엽서 상태, 엽서 이미지
>### 보낸 엽서 조회(/postcard/from) api 수정
>- DB 스키마 변경되면서 오류 발생하던 부분 수정

## 🙋🏻 More

> 보낸 엽서 조회(/postcard/from) api는 현재 사용하지 않지만 지우지는 않고, api가 정상 작동하도록 수정해두었습니다. 