### PR TITLE
카카오 인증 절차 변경 작업

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/bookbla/americano/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.bookbla.americano.domain.auth.controller;
 
+import com.bookbla.americano.domain.auth.controller.dto.request.KakaoLoginRequest;
 import com.bookbla.americano.domain.auth.controller.dto.request.LoginRequest;
 import com.bookbla.americano.domain.auth.controller.dto.response.LoginResponse;
 import com.bookbla.americano.domain.auth.service.AuthService;
@@ -25,6 +26,14 @@ public class AuthController {
             @PathVariable String oAuthType
     ) {
         LoginResponse loginResponse = authService.login(loginRequest, oAuthType);
+        return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/login/kakao-v2")
+    public ResponseEntity<LoginResponse> loginUsingKakao(
+            @RequestBody @Valid KakaoLoginRequest kakaoLoginRequest
+    ) {
+        LoginResponse loginResponse = authService.loginUsingKakao(kakaoLoginRequest);
         return ResponseEntity.ok(loginResponse);
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/auth/controller/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/auth/controller/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,16 @@
+package com.bookbla.americano.domain.auth.controller.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class KakaoLoginRequest {
+
+    @NotNull(message = "카카오 인증 액세스 토큰이 입력되지 않았습니다")
+    private String accessToken;
+}

--- a/src/main/java/com/bookbla/americano/domain/auth/service/AuthService.java
+++ b/src/main/java/com/bookbla/americano/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.auth.service;
 
 import com.bookbla.americano.base.jwt.JwtProvider;
+import com.bookbla.americano.domain.auth.controller.dto.request.KakaoLoginRequest;
 import com.bookbla.americano.domain.auth.controller.dto.request.LoginRequest;
 import com.bookbla.americano.domain.auth.controller.dto.response.LoginResponse;
 import com.bookbla.americano.domain.auth.service.dto.OAuth2MemberResponse;
@@ -26,6 +27,19 @@ public class AuthService {
         OAuth2MemberResponse oAuth2MemberResponse = oAuth2Provider.getMemberResponse(loginRequest.getAuthCode());
 
         Member member = memberRepository.findByMemberTypeAndOauthEmail(memberType, oAuth2MemberResponse.getEmail())
+                .orElseGet(() -> signUp(oAuth2MemberResponse));
+
+        String accessToken = jwtProvider.createToken(member.getId().toString());
+        return LoginResponse.of(accessToken, member);
+    }
+
+    public LoginResponse loginUsingKakao(KakaoLoginRequest kakaoLoginRequest) {
+        OAuth2Provider oAuth2Provider = oAuth2Providers.getProvider(MemberType.KAKAO);
+        OAuth2MemberResponse oAuth2MemberResponse = oAuth2Provider.getMemberResponse(
+                kakaoLoginRequest.getAccessToken());
+
+        Member member = memberRepository.findByMemberTypeAndOauthEmail(MemberType.KAKAO,
+                        oAuth2MemberResponse.getEmail())
                 .orElseGet(() -> signUp(oAuth2MemberResponse));
 
         String accessToken = jwtProvider.createToken(member.getId().toString());


### PR DESCRIPTION
## 📄 Summary

[AS-IS]
1. (FE) 인가 코드 발급 및 로그인 요청
2. (BE) 인가 코드 이용 액세스 토큰 발급
3. (BE) 액세스 토큰 이용 사용자 정보 획득
4. (BE) 자체 토큰 발급 및 로그인 처리

[TO-BE]
1. (FE) ~~인가 코드 발급 및 백엔드 로그인 요청~~ => **액세스 토큰 발급 받아 로그인 요청**
2. ~~BE) 인가 코드 이용 액세스 토큰 발급~~
3. (BE) 액세스 토큰 이용 사용자 정보 획득
4. (BE) 자체 토큰 발급 및 로그인 처리

>
## 🙋🏻 More
기존 컨트롤러는 남겨두고.. 카카오 로그인 전용 엔드포인트를 새로 만들었어요!
혹시 몰라서(사이드 이펙트)
>