### PR TITLE
카카오 인증 절차 변경 & 닉네임 변경 검증 조건 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/exception/MemberProfileExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/member/exception/MemberProfileExceptionType.java
@@ -12,7 +12,7 @@ public enum MemberProfileExceptionType implements ExceptionType {
     GENDER_NOT_VALID(HttpStatus.BAD_REQUEST, "member_profile_01", "유효하지 않은 성별입니다."),
     OKA_STATUS_NOT_VALID(HttpStatus.BAD_REQUEST, "member_profile_02", "유효하지 않은 오픈 카톡방 상태입니다."),
     ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "member_profile_03", "이미 사용중인 닉네임입니다."),
-    CONTAIN_BAD_WORDS(HttpStatus.BAD_REQUEST, "member_profile_04", "비속어가 포함되어있습니다."),
+    CONTAIN_BAD_WORDS(HttpStatus.BAD_REQUEST, "member_profile_04", "사용할 수 없는 단어가(비속어, 북블라 등) 포함되어있습니다."),
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "member_profile_05", "프로필이 등록되지 않은 회원입니다."),
     ;
 

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
@@ -1,13 +1,12 @@
 package com.bookbla.americano.domain.member.repository.entity;
 
-import java.time.LocalDate;
-import java.util.Objects;
-
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.enums.Gender;
 import com.bookbla.americano.domain.member.enums.StudentIdImageStatus;
 import com.bookbla.americano.domain.member.exception.MemberProfileExceptionType;
 import com.vane.badwordfiltering.BadWordFiltering;
+import java.time.LocalDate;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -45,7 +44,7 @@ public class MemberProfile {
     public MemberProfile updateName(String name) {
         BadWordFiltering badWordFiltering = new BadWordFiltering();
 
-        if (badWordFiltering.blankCheck(name)) {
+        if (badWordFiltering.blankCheck(name) || name.contains("북블라")) {
             throw new BaseException(MemberProfileExceptionType.CONTAIN_BAD_WORDS);
         }
 

--- a/src/test/java/com/bookbla/americano/domain/member/repository/entity/MemberProfileTest.java
+++ b/src/test/java/com/bookbla/americano/domain/member/repository/entity/MemberProfileTest.java
@@ -1,13 +1,13 @@
 package com.bookbla.americano.domain.member.repository.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bookbla.americano.base.exception.BaseException;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -27,5 +27,31 @@ class MemberProfileTest {
 
         // then
         assertThat(age).isEqualTo(20);
+    }
+
+    @Test
+    void 비속어_입력_시_닉네임_수정이_불가능_해야한다() {
+        //given
+        MemberProfile memberProfile = MemberProfile.builder()
+                .name("고도도")
+                .build();
+
+        //when then
+        assertThatThrownBy(() -> memberProfile.updateName("씨발"))
+                .isInstanceOf(BaseException.class)
+                .hasMessageContaining("사용할 수 없는 단어가(비속어, 북블라 등) 포함되어있습니다.");
+    }
+
+    @Test
+    void 북블라_입력_시_닉네임_수정이_불가능_해야한다() {
+        //given
+        MemberProfile memberProfile = MemberProfile.builder()
+                .name("고도도")
+                .build();
+
+        //when then
+        assertThatThrownBy(() -> memberProfile.updateName("북블라사랑해"))
+                .isInstanceOf(BaseException.class)
+                .hasMessageContaining("사용할 수 없는 단어가(비속어, 북블라 등) 포함되어있습니다.");
     }
 }


### PR DESCRIPTION
## 📄 Summary
[AS-IS]
(FE) 인가 코드 발급 및 로그인 요청
(BE) 인가 코드 이용 액세스 토큰 발급
(BE) 액세스 토큰 이용 사용자 정보 획득
(BE) 자체 토큰 발급 및 로그인 처리

[TO-BE]
(FE)~~인가 코드 발급 및 백엔드 로그인 요청~~ => **액세스 토큰 발급 받아 로그인 요청**
~~(BE) 인가 코드 이용 액세스 토큰 발급~~
(BE) 액세스 토큰 이용 사용자 정보 획득
(BE) 자체 토큰 발급 및 로그인 처리
>
## 🙋🏻 More
카카오 로그인 API 호출 DTO 필드를 accessToken으로 수정하여 컨트롤러와 서비스를 따로 만들려고 했으나, 
필드명 하나 바꿔줬다고 쓸데없이 중복코드가 발생하는 것 같아 기존 API 그대로 사용하고,
프론트에서 **액세스 토큰**을 기존처럼 동일 API에 authCode로 넘기는 방식으로 전파할게요~!

* 닉네임 변경 검증 조건 추가 간단해서 해당 PR에 같이 올릴게요..ㅎㅎ
>