### PR TITLE
fix: 학생증 사진을 등록되지 않은 상태 추가(UNREGISTER)

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/enums/StudentIdImageStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/member/enums/StudentIdImageStatus.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 public enum StudentIdImageStatus {
 
+    UNREGISTER,
     PENDING,
     DENIAL,
     DONE,

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberProfile.java
@@ -39,7 +39,8 @@ public class MemberProfile {
     private String studentIdImageUrl;
 
     @Enumerated(EnumType.STRING)
-    private StudentIdImageStatus studentIdImageStatus;
+    @Builder.Default
+    private StudentIdImageStatus studentIdImageStatus = StudentIdImageStatus.UNREGISTER;
 
     public MemberProfile updateName(String name) {
         BadWordFiltering badWordFiltering = new BadWordFiltering();


### PR DESCRIPTION
## 📄 Summary
`studentIdImageStatus`에 enum 타입에 학생증 사진이 등록되지 않은 상태인 `UNREGISTER`를 추가했습니다!
>
## 🙋🏻 More

>