### PR TITLE
feat: 애플 인앱결제 환불 구현

### DIFF
--- a/src/main/java/com/bookbla/americano/base/config/AuthConfig.java
+++ b/src/main/java/com/bookbla/americano/base/config/AuthConfig.java
@@ -36,7 +36,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/settings/**")
                 .excludePathPatterns("/schools")
                 .excludePathPatterns("/chat/ws/**")     // 채팅 웹소켓
-                .excludePathPatterns("/payment/in-app/apple/notification") // 애플 앱스토어 알림 받는 엔드포인트
+                .excludePathPatterns("/payments/in-app/apple/notification") // 애플 앱스토어 알림 받는 엔드포인트
         ;
 
         // 어드민 인터셉터

--- a/src/main/java/com/bookbla/americano/base/config/AuthConfig.java
+++ b/src/main/java/com/bookbla/americano/base/config/AuthConfig.java
@@ -36,6 +36,7 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/settings/**")
                 .excludePathPatterns("/schools")
                 .excludePathPatterns("/chat/ws/**")     // 채팅 웹소켓
+                .excludePathPatterns("/payment/in-app/apple/notification") // 애플 앱스토어 알림 받는 엔드포인트
         ;
 
         // 어드민 인터셉터

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBookmark.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberBookmark.java
@@ -74,6 +74,13 @@ public class MemberBookmark extends BaseEntity {
         this.bookmarkCount += count;
     }
 
+    public void refundBookmark(int count) {
+        if (this.bookmarkCount < count) {
+            throw new BaseException(MemberBookmarkExceptionType.INVALID_BOOKMARK_COUNTS);
+        }
+        this.bookmarkCount -= count;
+    }
+
     public void updateBookmarksByInitialBook(int memberBooks) {
         if (memberBooks >= 4) {
             this.bookmarkCount += 60;

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentController.java
@@ -4,13 +4,12 @@ import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.payment.controller.docs.PaymentControllerDocs;
 import com.bookbla.americano.domain.payment.controller.dto.request.GooglePaymentInAppPurchaseRequest;
-import com.bookbla.americano.domain.payment.controller.dto.request.PaymentInAppPurchaseRequest;
+import com.bookbla.americano.domain.payment.controller.dto.request.ApplePaymentInAppPurchaseRequest;
 import com.bookbla.americano.domain.payment.controller.dto.response.PaymentPurchaseResponse;
 import com.bookbla.americano.domain.payment.service.PaymentService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +25,7 @@ public class PaymentController implements PaymentControllerDocs {
     @PostMapping("/in-app/apple")
     public ResponseEntity<PaymentPurchaseResponse> orderBookmarkForApple(
         @User LoginUser loginUser,
-        @Valid @RequestBody PaymentInAppPurchaseRequest request
+        @Valid @RequestBody ApplePaymentInAppPurchaseRequest request
     ) {
         PaymentPurchaseResponse paymentPurchaseResponse = paymentService.orderBookmarkForApple(
             request, loginUser.getMemberId());

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentSubscriber.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentSubscriber.java
@@ -1,0 +1,24 @@
+package com.bookbla.americano.domain.payment.controller;
+
+import com.bookbla.americano.domain.payment.controller.dto.request.AppleNotificationRequest;
+import com.bookbla.americano.domain.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PaymentSubscriber {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/in-app/apple/notification")
+    public ResponseEntity<Void> receiveAppleNotification(
+            @RequestBody AppleNotificationRequest request
+    ) {
+        paymentService.receiveAppleNotification(request.getSignedPayload());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentSubscriber.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentSubscriber.java
@@ -20,12 +20,7 @@ public class PaymentSubscriber {
     public ResponseEntity<Void> receiveAppleNotification(
             @RequestBody AppleNotificationRequest request
     ) {
-        // 애플로부터 들어온 환불 정보는 모두 저장해두고 싶었으나
-        // 예외가 터지면 트랜잭션 커밋이 안 돼, 일단 이렇게 구현해놨습니다
-        boolean isSuccess = paymentService.receiveAppleNotification(request.getSignedPayload());
-        if (isSuccess) {
-            return ResponseEntity.ok().build();
-        }
-        return ResponseEntity.badRequest().build();
+        paymentService.receiveAppleNotification(request.getSignedPayload());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentSubscriber.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/PaymentSubscriber.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
+@RequestMapping("/payments")
 @RestController
 public class PaymentSubscriber {
 
@@ -18,7 +20,12 @@ public class PaymentSubscriber {
     public ResponseEntity<Void> receiveAppleNotification(
             @RequestBody AppleNotificationRequest request
     ) {
-        paymentService.receiveAppleNotification(request.getSignedPayload());
-        return ResponseEntity.ok().build();
+        // 애플로부터 들어온 환불 정보는 모두 저장해두고 싶었으나
+        // 예외가 터지면 트랜잭션 커밋이 안 돼, 일단 이렇게 구현해놨습니다
+        boolean isSuccess = paymentService.receiveAppleNotification(request.getSignedPayload());
+        if (isSuccess) {
+            return ResponseEntity.ok().build();
+        }
+        return ResponseEntity.badRequest().build();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/docs/PaymentControllerDocs.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/docs/PaymentControllerDocs.java
@@ -2,7 +2,7 @@ package com.bookbla.americano.domain.payment.controller.docs;
 
 import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
-import com.bookbla.americano.domain.payment.controller.dto.request.PaymentInAppPurchaseRequest;
+import com.bookbla.americano.domain.payment.controller.dto.request.ApplePaymentInAppPurchaseRequest;
 import com.bookbla.americano.domain.payment.controller.dto.response.PaymentPurchaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -48,7 +47,7 @@ public interface PaymentControllerDocs {
     @PostMapping
     ResponseEntity<PaymentPurchaseResponse> orderBookmarkForApple(
             @Parameter(hidden = true) @User LoginUser loginUser,
-            @Valid @RequestBody PaymentInAppPurchaseRequest request
+            @Valid @RequestBody ApplePaymentInAppPurchaseRequest request
 //            @PathVariable @Parameter(name = "payType", description = "인앱결제 유형입니다", example = "apple, google") String payType
     );
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/dto/request/AppleNotificationRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/dto/request/AppleNotificationRequest.java
@@ -1,0 +1,15 @@
+package com.bookbla.americano.domain.payment.controller.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class AppleNotificationRequest {
+
+    private String signedPayload;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/dto/request/ApplePaymentInAppPurchaseRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/dto/request/ApplePaymentInAppPurchaseRequest.java
@@ -1,6 +1,5 @@
 package com.bookbla.americano.domain.payment.controller.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,9 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class PaymentInAppPurchaseRequest {
+public class ApplePaymentInAppPurchaseRequest {
 
-    @Schema(name = "인앱결제 후 받은 영수증 정보", example = "109886")
     @NotBlank(message = "영수증 정보가 입력되지 않았습니다.")
     private String transactionId;
 

--- a/src/main/java/com/bookbla/americano/domain/payment/controller/dto/request/GooglePaymentInAppPurchaseRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/controller/dto/request/GooglePaymentInAppPurchaseRequest.java
@@ -13,11 +13,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class GooglePaymentInAppPurchaseRequest {
 
-    @Schema(name = "인앱결제 후 받은 영수증 정보", example = "bookmark_01")
+    @Schema(example = "bookmark_01")
     @NotBlank(message = "인앱 상품 ID가 입력되지 않았습니다.")
     private String productId;
 
-    @Schema(name = "인앱결제 후 받은 영수증 정보", example = "109886")
+    @Schema(example = "109886")
     @NotBlank(message = "인앱 상품 토큰이 입력되지 않았습니다.")
     private String purchaseToken;
 

--- a/src/main/java/com/bookbla/americano/domain/payment/exception/PaymentExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/exception/PaymentExceptionType.java
@@ -11,6 +11,7 @@ public enum PaymentExceptionType implements ExceptionType {
 
     PAYMENT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "payment-001", "존재하지 않는 결제 타입입니다"),
     NOT_VALID_PAYMENT_ID(HttpStatus.NOT_FOUND, "payment-002", "존재하지 않는 결제 메뉴입니다"),
+    RECEIPT_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "payment-003", "해당 결제 정보가 존재하지 않습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/AppleLibraryProvider.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/AppleLibraryProvider.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import com.apple.itunes.storekit.client.APIException;
 import com.apple.itunes.storekit.client.AppStoreServerAPIClient;
 import com.apple.itunes.storekit.model.Environment;
+import com.apple.itunes.storekit.model.ResponseBodyV2DecodedPayload;
 import com.apple.itunes.storekit.verification.SignedDataVerifier;
 import com.apple.itunes.storekit.verification.VerificationException;
 import com.bookbla.americano.AmericanoApplication;
@@ -15,6 +16,7 @@ import com.bookbla.americano.domain.payment.infrastructure.apple.config.ApplePay
 import com.bookbla.americano.domain.payment.infrastructure.apple.exception.ApplePaymentExceptionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -41,13 +43,7 @@ class AppleLibraryProvider {
     }
 
     public void validateTransaction(String transactionId) {
-        String bundleId = applePaymentsConfig.getBundleId();
-        Environment environment = Environment.fromValue(applePaymentsConfig.getEnviornment());
-        long appId = applePaymentsConfig.getAppId();
-
-        Set<InputStream> rootCAS = readCAS();
-
-        SignedDataVerifier signedDataVerifier = new SignedDataVerifier(rootCAS, bundleId, appId, environment, true);
+        SignedDataVerifier signedDataVerifier = createSignedDataVerifier();
         try {
             signedDataVerifier.verifyAndDecodeTransaction(transactionId);
         } catch (VerificationException e) {
@@ -63,5 +59,25 @@ class AppleLibraryProvider {
                 AmericanoApplication.class.getResourceAsStream("/AppleComputerRootCertificate.cer"),
                 AmericanoApplication.class.getResourceAsStream("/AppleIncRootCertificate.cer")
         );
+    }
+
+    public ResponseBodyV2DecodedPayload getNotificationPayload(String signedPayload) {
+        SignedDataVerifier signedDataVerifier = createSignedDataVerifier();
+        try {
+            return signedDataVerifier.verifyAndDecodeNotification(signedPayload);
+        } catch (VerificationException e) {
+            log.error(e.getMessage());
+            throw new BaseException(ApplePaymentExceptionType.INVALID_APPLE_KEY, e);
+        }
+    }
+
+    private @NotNull SignedDataVerifier createSignedDataVerifier() {
+        String bundleId = applePaymentsConfig.getBundleId();
+        Environment environment = Environment.fromValue(applePaymentsConfig.getEnviornment());
+        long appId = applePaymentsConfig.getAppId();
+
+        Set<InputStream> rootCAS = readCAS();
+
+        return new SignedDataVerifier(rootCAS, bundleId, appId, environment, true);
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/AppleLibraryProvider.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/AppleLibraryProvider.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-public class AppleLibraryProvider {
+class AppleLibraryProvider {
 
     private final ApplePaymentsConfig applePaymentsConfig;
 

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/AppleLibraryProvider.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/AppleLibraryProvider.java
@@ -52,16 +52,7 @@ class AppleLibraryProvider {
         }
     }
 
-    private Set<InputStream> readCAS() {
-        return Set.of(
-                AmericanoApplication.class.getResourceAsStream("/AppleRootCA-G2.cer"),
-                AmericanoApplication.class.getResourceAsStream("/AppleRootCA-G3.cer"),
-                AmericanoApplication.class.getResourceAsStream("/AppleComputerRootCertificate.cer"),
-                AmericanoApplication.class.getResourceAsStream("/AppleIncRootCertificate.cer")
-        );
-    }
-
-    public ResponseBodyV2DecodedPayload getNotificationPayload(String signedPayload) {
+    public ResponseBodyV2DecodedPayload getNotificationDecodedPayload(String signedPayload) {
         SignedDataVerifier signedDataVerifier = createSignedDataVerifier();
         try {
             return signedDataVerifier.verifyAndDecodeNotification(signedPayload);
@@ -76,8 +67,17 @@ class AppleLibraryProvider {
         Environment environment = Environment.fromValue(applePaymentsConfig.getEnviornment());
         long appId = applePaymentsConfig.getAppId();
 
-        Set<InputStream> rootCAS = readCAS();
+        Set<InputStream> rootCAS = readCAs();
 
         return new SignedDataVerifier(rootCAS, bundleId, appId, environment, true);
+    }
+
+    private @NotNull Set<InputStream> readCAs() {
+        return Set.of(
+                AmericanoApplication.class.getResourceAsStream("/AppleRootCA-G2.cer"),
+                AmericanoApplication.class.getResourceAsStream("/AppleRootCA-G3.cer"),
+                AmericanoApplication.class.getResourceAsStream("/AppleComputerRootCertificate.cer"),
+                AmericanoApplication.class.getResourceAsStream("/AppleIncRootCertificate.cer")
+        );
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/ApplePaymentStrategy.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/ApplePaymentStrategy.java
@@ -31,7 +31,7 @@ public class ApplePaymentStrategy implements PaymentStrategy {
                 .bookmark(paymentTable.getCount())
                 .paymentType(PaymentType.APPLE)
                 .receipt(transactionId)
-                .json(signedTransactionInfo)
+                .information(signedTransactionInfo)
                 .build();
     }
 
@@ -46,7 +46,7 @@ public class ApplePaymentStrategy implements PaymentStrategy {
         DecodedTokenPayload payload = appleTokenProvider.decodePayload(signedTransactionInfo);
 
         return PaymentNotification.builder()
-                .json(signedTransactionInfo)
+                .information(signedTransactionInfo)
                 .type(notificationType)
                 .receipt(payload.getTransactionId())
                 .productId(payload.getProductId())

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/ApplePaymentStrategy.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/ApplePaymentStrategy.java
@@ -1,5 +1,7 @@
 package com.bookbla.americano.domain.payment.infrastructure.apple;
 
+import com.apple.itunes.storekit.model.NotificationTypeV2;
+import com.apple.itunes.storekit.model.ResponseBodyV2DecodedPayload;
 import com.bookbla.americano.domain.payment.enums.PaymentTable;
 import com.bookbla.americano.domain.payment.enums.PaymentType;
 import com.bookbla.americano.domain.payment.infrastructure.apple.tokens.DecodedTokenPayload;
@@ -30,6 +32,11 @@ public class ApplePaymentStrategy implements PaymentStrategy {
                 .paymentType(PaymentType.APPLE)
                 .receipt(transactionId)
                 .build();
+    }
+
+    @Override
+    public void getNotificationInformation(String id) {
+        ResponseBodyV2DecodedPayload notificationPayload = appleLibraryProvider.getNotificationPayload(id);
     }
 
     @Override

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/ApplePaymentStrategy.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/apple/ApplePaymentStrategy.java
@@ -37,7 +37,7 @@ public class ApplePaymentStrategy implements PaymentStrategy {
 
     @Override
     public PaymentNotification getNotificationInformation(String id) {
-        ResponseBodyV2DecodedPayload notificationPayload = appleLibraryProvider.getNotificationPayload(id);
+        ResponseBodyV2DecodedPayload notificationPayload = appleLibraryProvider.getNotificationDecodedPayload(id);
         String notificationType = notificationPayload.getNotificationType().getValue();
         String signedTransactionInfo = notificationPayload.getData().getSignedTransactionInfo();
 

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
@@ -34,9 +34,9 @@ public class Payment extends BaseEntity {
 
     private int bookmark;
 
-    private String receipt;
+    private String receipt; // 거래 후 받는 영수증 정보
 
-    private String json;
+    private String information; // 서버로부터 받는 json 정보
 
     @Enumerated(EnumType.STRING)
     private PaymentType paymentType;

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.payment.repository;
 import java.math.BigDecimal;
 
 import com.bookbla.americano.base.entity.BaseEntity;
+import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
 import com.bookbla.americano.domain.payment.enums.PaymentType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -42,5 +43,9 @@ public class Payment extends BaseEntity {
 
     public void updateMemberId(Long memberId) {
         this.memberId = memberId;
+    }
+
+    public boolean canRefund(MemberBookmark memberBookmark) {
+        return memberBookmark.getBookmarkCount() >= bookmark;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
@@ -1,12 +1,7 @@
 package com.bookbla.americano.domain.payment.repository;
 
-import java.math.BigDecimal;
-
 import com.bookbla.americano.base.entity.BaseEntity;
-import com.bookbla.americano.domain.payment.enums.PaymentType;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -18,29 +13,22 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 @Getter
+@Builder
 @Entity
-public class Payment extends BaseEntity {
+public class PaymentNotification extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long memberId;
-
-    private BigDecimal money;
-
-    private int bookmark;
-
-    private String receipt;
+    private String type;
 
     private String json;
 
-    @Enumerated(EnumType.STRING)
-    private PaymentType paymentType;
+    private String receipt;
 
-    public void updateMemberId(Long memberId) {
-        this.memberId = memberId;
-    }
+    private String productId;
+
+
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
@@ -30,5 +30,8 @@ public class PaymentNotification extends BaseEntity {
 
     private String productId;
 
+    public boolean isRefund() {
+        return type.equalsIgnoreCase("REFUND");
+    }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
@@ -24,9 +24,9 @@ public class PaymentNotification extends BaseEntity {
 
     private String type;
 
-    private String json;
+    private String information; // 서버로부터 받는 json 정보
 
-    private String receipt;
+    private String receipt; // 거래 후 받은 영수증 정보
 
     private String productId;
 

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotificationRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotificationRepository.java
@@ -1,0 +1,7 @@
+package com.bookbla.americano.domain.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentNotificationRepository extends JpaRepository<PaymentNotification, Long> {
+
+}

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentRepository.java
@@ -1,7 +1,11 @@
 package com.bookbla.americano.domain.payment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByReceipt(String receipt);
 
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -5,7 +5,7 @@ import com.bookbla.americano.domain.member.exception.MemberBookmarkExceptionType
 import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
 import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
 import com.bookbla.americano.domain.payment.controller.dto.request.GooglePaymentInAppPurchaseRequest;
-import com.bookbla.americano.domain.payment.controller.dto.request.PaymentInAppPurchaseRequest;
+import com.bookbla.americano.domain.payment.controller.dto.request.ApplePaymentInAppPurchaseRequest;
 import com.bookbla.americano.domain.payment.controller.dto.response.PaymentPurchaseResponse;
 import com.bookbla.americano.domain.payment.infrastructure.google.GooglePaymentStrategy;
 import com.bookbla.americano.domain.payment.repository.Payment;
@@ -24,7 +24,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final MemberBookmarkRepository memberBookmarkRepository;
 
-    public PaymentPurchaseResponse orderBookmarkForApple(PaymentInAppPurchaseRequest request, Long memberId) {
+    public PaymentPurchaseResponse orderBookmarkForApple(ApplePaymentInAppPurchaseRequest request, Long memberId) {
         PaymentStrategy paymentStrategy = paymentStrategies.find("apple");
 
         Payment payment = paymentStrategy.getPaymentInformation(request.getTransactionId());

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -55,6 +55,7 @@ public class PaymentService {
         return PaymentPurchaseResponse.from(payment);
     }
 
+    // https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/handling_refund_notifications
     public void receiveAppleNotification(String signedPayload) {
         PaymentStrategy applePaymentStrategy = paymentStrategies.findApple();
         PaymentNotification paymentNotification = applePaymentStrategy.getNotificationInformation(signedPayload);
@@ -64,6 +65,8 @@ public class PaymentService {
             paymentRepository.findByReceipt(receipt)
                     .ifPresent(this::processRefund);
         }
+
+        paymentNotificationRepository.save(paymentNotification);
     }
 
     private void processRefund(Payment payment) {

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -4,8 +4,8 @@ import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.exception.MemberBookmarkExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
 import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
-import com.bookbla.americano.domain.payment.controller.dto.request.GooglePaymentInAppPurchaseRequest;
 import com.bookbla.americano.domain.payment.controller.dto.request.ApplePaymentInAppPurchaseRequest;
+import com.bookbla.americano.domain.payment.controller.dto.request.GooglePaymentInAppPurchaseRequest;
 import com.bookbla.americano.domain.payment.controller.dto.response.PaymentPurchaseResponse;
 import com.bookbla.americano.domain.payment.infrastructure.google.GooglePaymentStrategy;
 import com.bookbla.americano.domain.payment.repository.Payment;
@@ -25,9 +25,9 @@ public class PaymentService {
     private final MemberBookmarkRepository memberBookmarkRepository;
 
     public PaymentPurchaseResponse orderBookmarkForApple(ApplePaymentInAppPurchaseRequest request, Long memberId) {
-        PaymentStrategy paymentStrategy = paymentStrategies.find("apple");
+        PaymentStrategy applePaymentStrategy = paymentStrategies.findApple();
 
-        Payment payment = paymentStrategy.getPaymentInformation(request.getTransactionId());
+        Payment payment = applePaymentStrategy.getPaymentInformation(request.getTransactionId());
         payment.updateMemberId(memberId);
         paymentRepository.save(payment);
 
@@ -47,7 +47,7 @@ public class PaymentService {
         paymentRepository.save(payment);
 
         MemberBookmark memberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(memberId)
-            .orElseThrow(() -> new BaseException(MemberBookmarkExceptionType.MEMBER_ID_NOT_EXISTS));
+                .orElseThrow(() -> new BaseException(MemberBookmarkExceptionType.MEMBER_ID_NOT_EXISTS));
 
         int updateCount = payment.getBookmark();
         memberBookmark.addBookmark(updateCount);
@@ -56,6 +56,7 @@ public class PaymentService {
     }
 
     public void receiveAppleNotification(String signedPayload) {
-
+        PaymentStrategy applePaymentStrategy = paymentStrategies.findApple();
+        applePaymentStrategy.getNotificationInformation(signedPayload);
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -9,6 +9,7 @@ import com.bookbla.americano.domain.payment.controller.dto.request.GooglePayment
 import com.bookbla.americano.domain.payment.controller.dto.response.PaymentPurchaseResponse;
 import com.bookbla.americano.domain.payment.infrastructure.google.GooglePaymentStrategy;
 import com.bookbla.americano.domain.payment.repository.Payment;
+import com.bookbla.americano.domain.payment.repository.PaymentNotification;
 import com.bookbla.americano.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,6 +58,7 @@ public class PaymentService {
 
     public void receiveAppleNotification(String signedPayload) {
         PaymentStrategy applePaymentStrategy = paymentStrategies.findApple();
-        applePaymentStrategy.getNotificationInformation(signedPayload);
+        PaymentNotification notificationInformation = applePaymentStrategy.getNotificationInformation(signedPayload);
+
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -54,4 +54,8 @@ public class PaymentService {
 
         return PaymentPurchaseResponse.from(payment);
     }
+
+    public void receiveAppleNotification(String signedPayload) {
+
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.payment.service;
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.exception.MemberBookmarkExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
+import com.bookbla.americano.domain.member.repository.MemberRepository;
 import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
 import com.bookbla.americano.domain.payment.controller.dto.request.ApplePaymentInAppPurchaseRequest;
 import com.bookbla.americano.domain.payment.controller.dto.request.GooglePaymentInAppPurchaseRequest;
@@ -27,6 +28,7 @@ public class PaymentService {
     private final GooglePaymentStrategy googlePaymentStrategy;
     private final PaymentRepository paymentRepository;
     private final MemberBookmarkRepository memberBookmarkRepository;
+    private final MemberRepository memberRepository;
 
     public PaymentPurchaseResponse orderBookmarkForApple(ApplePaymentInAppPurchaseRequest request, Long memberId) {
         PaymentStrategy applePaymentStrategy = paymentStrategies.findApple();
@@ -69,8 +71,10 @@ public class PaymentService {
     }
 
     private void handleRefund(PaymentNotification paymentNotification) {
-        String receipt = paymentNotification.getReceipt();
-        Payment payment = findPaymentByReceipt(receipt);
+        Payment payment = findPaymentByReceipt(paymentNotification.getReceipt());
+        if (!memberRepository.existsById(payment.getMemberId())) {
+            return;
+        }
 
         MemberBookmark memberBookmark = findMemberBookmarkByMemberId(payment.getMemberId());
 

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentService.java
@@ -76,7 +76,7 @@ public class PaymentService {
         MemberBookmark memberBookmark = findMemberBookmarkByMemberId(payment.getMemberId());
 
         if (payment.canRefund(memberBookmark)) {
-            memberBookmark.addBookmark(payment.getBookmark());
+            memberBookmark.refundBookmark(payment.getBookmark());
             return true;
         }
 

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentStrategies.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentStrategies.java
@@ -27,4 +27,8 @@ public class PaymentStrategies {
         PaymentType paymentType = PaymentType.from(value);
         return paymentStrategyMap.get(paymentType);
     }
+
+    public PaymentStrategy findApple() {
+        return paymentStrategyMap.get(PaymentType.APPLE);
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentStrategy.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentStrategy.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.payment.service;
 
 import com.bookbla.americano.domain.payment.enums.PaymentType;
 import com.bookbla.americano.domain.payment.repository.Payment;
+import com.bookbla.americano.domain.payment.repository.PaymentNotification;
 
 public interface PaymentStrategy {
 
@@ -9,6 +10,6 @@ public interface PaymentStrategy {
 
     Payment getPaymentInformation(String id);
 
-    void getNotificationInformation(String id);
+    PaymentNotification getNotificationInformation(String id);
 
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/service/PaymentStrategy.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/service/PaymentStrategy.java
@@ -9,4 +9,6 @@ public interface PaymentStrategy {
 
     Payment getPaymentInformation(String id);
 
+    void getNotificationInformation(String id);
+
 }

--- a/src/main/java/com/bookbla/americano/scheduler/ScheduleWorker.java
+++ b/src/main/java/com/bookbla/americano/scheduler/ScheduleWorker.java
@@ -31,7 +31,7 @@ import static com.bookbla.americano.scheduler.Crons.EVERY_4_AM;
 @Slf4j
 class ScheduleWorker {
 
-    private static final String CLRF = "\n\n";
+    private static final String CRLF = "\n\n";
 
     private final MemberRepository memberRepository;
     private final MemberEmailRepository memberEmailRepository;
@@ -49,8 +49,8 @@ class ScheduleWorker {
 
         } catch (Exception e) {
             String txName = ScheduleWorker.class.getName() + "(deleteMemberEmailSchedule)";
-            String message = "임시 메일 테이블 초기화 작업이 실패하였습니다. 확인 부탁드립니다." + CLRF
-                    + e.getMessage() + CLRF
+            String message = "임시 메일 테이블 초기화 작업이 실패하였습니다. 확인 부탁드립니다." + CRLF
+                    + e.getMessage() + CRLF
                     + stackTraceToString(e);
 
             mailService.sendTransactionFailureEmail(txName, message);
@@ -71,8 +71,8 @@ class ScheduleWorker {
             memberRepository.deleteAllByDeletedAtBeforeAndMemberStatus(thirtyDaysAgo);
         } catch (Exception e) {
             String txName = ScheduleWorker.class.getName() + "(deleteMemberSchedule)";
-            String message = "멤버 테이블의 탈퇴한 멤버 삭제 작업이 실패하였습니다. 확인 부탁드립니다. " + CLRF
-                    + e.getMessage() + CLRF
+            String message = "멤버 테이블의 탈퇴한 멤버 삭제 작업이 실패하였습니다. 확인 부탁드립니다. " + CRLF
+                    + e.getMessage() + CRLF
                     + stackTraceToString(e);
 
             mailService.sendTransactionFailureEmail(txName, message);
@@ -90,8 +90,8 @@ class ScheduleWorker {
             memberBookmarkRepository.resetAdmobCount(2);
         } catch (Exception e) {
             String txName = ScheduleWorker.class.getName() + "(resetAdmobCount)";
-            String message = "애드몹 시청 횟수 초기화 기능 실패  " + CLRF
-                    + e.getMessage() + CLRF
+            String message = "애드몹 시청 횟수 초기화 기능 실패  " + CRLF
+                    + e.getMessage() + CRLF
                     + stackTraceToString(e);
 
             mailService.sendTransactionFailureEmail(txName, message);
@@ -124,8 +124,8 @@ class ScheduleWorker {
             }
         } catch (Exception e) {
             String txName = ScheduleWorker.class.getName() + "(removeExpiredPostcardSchedule)";
-            String message = "만료 된 엽서 삭제 작업이 실패하였습니다. 확인 부탁드립니다." + CLRF
-                    + e.getMessage() + CLRF
+            String message = "만료 된 엽서 삭제 작업이 실패하였습니다. 확인 부탁드립니다." + CRLF
+                    + e.getMessage() + CRLF
                     + stackTraceToString(e);
 
             mailService.sendTransactionFailureEmail(txName, message);


### PR DESCRIPTION
## 📄 Summary

> 
애플 환불 구현했습니다

애플의 인앱결제 환불 플로우는 다음과 같아요

```mermaid
sequenceDiagram 
    Autonumber
    participant Client
    participant Apple Server
    participant Bookbla Server

    Client->>Apple Server: 환불 신청
    Apple Server->>Bookbla Server: 인앱 결제 공지
    Bookbla Server->>Bookbla Server: 환불 검증
    Bookbla Server->>Apple Server: 200번 || 400번
    Apple Server->>Client: 환불 결과 알림
```

애플로 부터 받은 응답이 유효할 경우, 200번대 응답을 주면 되고
실패할 경우, 400번대를 던져주면 됩니다

애플에서 받은 모든 정보를 DB에 저장해두고 싶어서, 최대한 비즈니스 단에서 예외를 던지지 않는 방식으로 만들어놨습니다
덕분에 컨트롤러단에서 분기를 타는 진짜 해괴한 방식이 되었네요...ㅋㅋㅋ

환불 신청 내역을 애플 개발자 계정에서 확인할 수 있다면... 제일 좋은 방법일 것 같은데, 묘수가 잘 떠오르지 않습니다

돈 관련된 로직이다보니 여유 되신다면 꼭 리뷰 부탁드리겠습니다!

## 🙋🏻 More

> https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/handling_refund_notifications
