### PR TITLE
fix: 9/18 트러블 슈팅 내역 반영

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/book/infra/kakao/dto/KakaoBookResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/book/infra/kakao/dto/KakaoBookResponse.java
@@ -46,6 +46,7 @@ public class KakaoBookResponse {
     public BookSearchResponses toBookSearchResponsesWith(int page) {
         List<BookSearchResponse> bookSearchResponses = documents.stream()
                 .map(it -> new BookSearchResponse(it.title, it.authors, toIsbn13(it.getIsbn()), it.thumbnail))
+                .distinct()
                 .collect(Collectors.toList());
         return BookSearchResponses.builder()
                 .totalCount(getMeta().pageableCount)

--- a/src/main/java/com/bookbla/americano/domain/book/service/dto/BookSearchResponses.java
+++ b/src/main/java/com/bookbla/americano/domain/book/service/dto/BookSearchResponses.java
@@ -2,6 +2,8 @@ package com.bookbla.americano.domain.book.service.dto;
 
 
 import java.util.List;
+import java.util.Objects;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -22,16 +24,25 @@ public class BookSearchResponses {
 
     @Getter
     @RequiredArgsConstructor
-    @EqualsAndHashCode
     public static class BookSearchResponse {
 
         private final String title;
         private final List<String> authors;
-
-        @EqualsAndHashCode.Include
         private final String isbn;
         private final String imageUrl;
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof BookSearchResponse)) return false;
+            final BookSearchResponse that = (BookSearchResponse) o;
+            return Objects.equals(isbn, that.isbn);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(isbn);
+        }
     }
 
     public boolean getIsEnd() {

--- a/src/main/java/com/bookbla/americano/domain/book/service/dto/BookSearchResponses.java
+++ b/src/main/java/com/bookbla/americano/domain/book/service/dto/BookSearchResponses.java
@@ -4,6 +4,7 @@ package com.bookbla.americano.domain.book.service.dto;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -21,10 +22,13 @@ public class BookSearchResponses {
 
     @Getter
     @RequiredArgsConstructor
+    @EqualsAndHashCode
     public static class BookSearchResponse {
 
         private final String title;
         private final List<String> authors;
+
+        @EqualsAndHashCode.Include
         private final String isbn;
         private final String imageUrl;
 

--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberController.java
@@ -48,9 +48,9 @@ public class MemberController {
     @PostMapping("/status")
     public ResponseEntity<MemberStatusResponse> updateMemberStatus(
             @Parameter(hidden = true) @User LoginUser loginUser,
-            @RequestBody @Valid MemberStatusUpdateRequest memberStatusUpdateRequest
+            @RequestBody @Valid MemberStatusUpdateRequest request
     ) {
-        MemberStatusResponse memberStatusResponse = memberService.updateStatus(loginUser.getMemberId(), memberStatusUpdateRequest.getMemberStatus());
+        MemberStatusResponse memberStatusResponse = memberService.updateStatus(loginUser.getMemberId(), request);
         return ResponseEntity.ok(memberStatusResponse);
     }
 

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStatusUpdateRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/MemberStatusUpdateRequest.java
@@ -15,4 +15,6 @@ public class MemberStatusUpdateRequest {
     @NotNull(message = "변경 할 상태를 입력하지 않았습니다.")
     private MemberStatus memberStatus;
 
+    private String reason;
+
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import com.bookbla.americano.base.entity.BaseEntity;
 import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
 import com.bookbla.americano.domain.payment.enums.PaymentType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -36,6 +37,7 @@ public class Payment extends BaseEntity {
 
     private String receipt; // 거래 후 받는 영수증 정보
 
+    @Column(columnDefinition = "TEXT")
     private String information; // 서버로부터 받는 json 정보
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentNotification.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.payment.repository;
 
 import com.bookbla.americano.base.entity.BaseEntity;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -24,6 +25,7 @@ public class PaymentNotification extends BaseEntity {
 
     private String type;
 
+    @Column(columnDefinition = "TEXT")
     private String information; // 서버로부터 받는 json 정보
 
     private String receipt; // 거래 후 받은 영수증 정보

--- a/src/main/java/com/bookbla/americano/domain/school/repository/entity/Invitation.java
+++ b/src/main/java/com/bookbla/americano/domain/school/repository/entity/Invitation.java
@@ -34,7 +34,7 @@ public class Invitation extends BaseEntity {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
-    private InvitationStatus invitationStatus = PENDING;
+    private InvitationStatus invitationStatus = BOOKMARK;
 
     @Enumerated(EnumType.STRING)
     private InvitationType invitationType;

--- a/src/main/java/com/bookbla/americano/domain/school/repository/entity/InvitationStatus.java
+++ b/src/main/java/com/bookbla/americano/domain/school/repository/entity/InvitationStatus.java
@@ -2,7 +2,6 @@ package com.bookbla.americano.domain.school.repository.entity;
 
 public enum InvitationStatus {
 
-    PENDING,
     COMPLETED,
     BOOKMARK,
     ;

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -51,13 +51,13 @@ public class InvitationService {
     }
 
     public InvitationResponse entryInvitationCode(Long invitedMemberId, InvitationCodeEntryRequest request) {
+        validateInvitation(invitedMemberId, request.getInvitationCode());
+
         if (FESTIVAL_TEMPORARY_INVITATION_CODE.equals(request.getInvitationCode())) {
             Invitation invitation = createFestivalInvitation(invitedMemberId);
             invitation.bookmark();
             return InvitationResponse.from(invitation);
         }
-
-        validateInvitation(invitedMemberId, request.getInvitationCode());
 
         Member invitingMember = memberRepository.findByInvitationCode(request.getInvitationCode())
                 .orElseThrow(() -> new BaseException(MemberExceptionType.INVITATION_CODE_NOT_FOUND));
@@ -71,16 +71,6 @@ public class InvitationService {
         return InvitationResponse.from(invitation);
     }
 
-    private @NotNull Invitation createFestivalInvitation(Long invitedMemberId) {
-        MemberBookmark invitedMemberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(invitedMemberId)
-                .orElseThrow(() -> new BaseException(MemberBookmarkExceptionType.MEMBER_ID_NOT_EXISTS));
-        invitedMemberBookmark.addBookmark(105);
-
-        adminNotificationEventListener.sendMessage(new AdminNotificationEvent("축제 코드 입력 +1", "memberId " + invitedMemberId));
-
-        return invitationRepository.save(Invitation.fromTempFestival(invitedMemberId));
-    }
-
     private void validateInvitation(Long invitedMemberId, String invitationCode) {
         if (invitationRepository.existsByInvitedMemberId(invitedMemberId)) {
             throw new BaseException(InvitationExceptionType.INVITATION_EXISTS);
@@ -90,6 +80,16 @@ public class InvitationService {
         if (member.getInvitationCode().equals(invitationCode)) {
             throw new BaseException(InvitationExceptionType.INVALID_INVITATION_CODE_MYSELF);
         }
+    }
+
+    private @NotNull Invitation createFestivalInvitation(Long invitedMemberId) {
+        MemberBookmark invitedMemberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(invitedMemberId)
+                .orElseThrow(() -> new BaseException(MemberBookmarkExceptionType.MEMBER_ID_NOT_EXISTS));
+        invitedMemberBookmark.addBookmark(105);
+
+        adminNotificationEventListener.sendMessage(new AdminNotificationEvent("축제 코드 입력 +1", "memberId " + invitedMemberId));
+
+        return invitationRepository.save(Invitation.fromTempFestival(invitedMemberId));
     }
 
     private Invitation createInvitation(


### PR DESCRIPTION
## 📄 Summary

>
- Payment Entity 내 json을 저장하기 위한 information 필드 TEXT 타입 명시
- 매칭 비활성화시 사유 저장
- 카카오 도서검색시 중복 데이터 제거
- 초대코드 입력시 축제 임시 초대코드 중복 입력 가능했던 것 수정

## 🙋🏻 More

>