### PR TITLE
Fix/google purchase response

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/payment/enums/PurchaseState.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/enums/PurchaseState.java
@@ -1,0 +1,24 @@
+package com.bookbla.americano.domain.payment.enums;
+
+import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.payment.exception.PurchaseStateExceptionType;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum PurchaseState {
+    PURCHASED(0),
+    CANCELED(1),
+    PENDING(2);
+
+    private final int value;
+
+    public static PurchaseState from(int value) {
+        return Arrays.stream(values())
+            .filter(it -> it.getValue() == value)
+            .findFirst()
+            .orElseThrow(() -> new BaseException(PurchaseStateExceptionType.PURCHASE_STATE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/payment/exception/PurchaseStateExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/exception/PurchaseStateExceptionType.java
@@ -1,0 +1,18 @@
+package com.bookbla.americano.domain.payment.exception;
+
+import com.bookbla.americano.base.exception.ExceptionType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum PurchaseStateExceptionType implements ExceptionType {
+
+    PURCHASE_STATE_NOT_FOUND(HttpStatus.NOT_FOUND, "purchase-state-001", "존재하지 않는 결제 상태 타입입니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/google/GoogleCertificationProvider.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/google/GoogleCertificationProvider.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.payment.infrastructure.google;
 
 import com.bookbla.americano.base.exception.BaseException;
+import com.bookbla.americano.domain.payment.enums.PurchaseState;
 import com.bookbla.americano.domain.payment.infrastructure.google.api.dto.response.GooglePaymentPurchaseResponse;
 import com.bookbla.americano.domain.payment.infrastructure.google.config.GooglePaymentConfig;
 import com.bookbla.americano.domain.payment.infrastructure.google.exception.GooglePaymentExceptionType;
@@ -44,8 +45,7 @@ public class GoogleCertificationProvider {
     }
 
     public void verifyPurchaseState(int purchaseState) {
-        // 0. Purchased(구매), 1. Canceled(취소), 2. Pending(대기)
-        if (purchaseState != 0) {
+        if (PurchaseState.from(purchaseState) != PurchaseState.PURCHASED) {
             throw new BaseException(GooglePaymentExceptionType.NOT_PURCHASE);
         }
     }

--- a/src/main/java/com/bookbla/americano/domain/payment/infrastructure/google/GooglePaymentStrategy.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/infrastructure/google/GooglePaymentStrategy.java
@@ -5,6 +5,8 @@ import com.bookbla.americano.domain.payment.enums.PaymentTable;
 import com.bookbla.americano.domain.payment.enums.PaymentType;
 import com.bookbla.americano.domain.payment.infrastructure.google.api.dto.response.GooglePaymentPurchaseResponse;
 import com.bookbla.americano.domain.payment.repository.Payment;
+import com.bookbla.americano.domain.payment.repository.PaymentRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,30 +17,24 @@ import org.springframework.stereotype.Component;
 public class GooglePaymentStrategy {
 
     private final GoogleCertificationProvider googleCertificationProvider;
+    private final PaymentRepository paymentRepository;
 
     public Payment getPaymentInformation(GooglePaymentInAppPurchaseRequest request) {
         GooglePaymentPurchaseResponse response = googleCertificationProvider.getPurchaseReceipt(
             request.getProductId(), request.getPurchaseToken());
 
-        log.info("getPaymentInformation -> response.getKind : " + response.getKind());
-        log.info("getPaymentInformation -> response.getPurchaseTimeMillis : " + response.getPurchaseTimeMillis());
-        log.info("getPaymentInformation -> response.getPurchaseState : " + response.getPurchaseState());
-        log.info("getPaymentInformation -> response.getConsumptionState : " + response.getConsumptionState());
-        log.info("getPaymentInformation -> response.getDeveloperPayload : " + response.getDeveloperPayload());
-        log.info("getPaymentInformation -> response.getOrderId : " + response.getOrderId());
-        log.info("getPaymentInformation -> response.getPurchaseType : " + response.getPurchaseType());
-        log.info("getPaymentInformation -> response.getAcknowledgementState : " + response.getAcknowledgementState());
-        log.info("getPaymentInformation -> response.getPurchaseToken : " + response.getPurchaseToken());
-        log.info("getPaymentInformation -> response.getProductId : " + response.getProductId());
-
         PaymentTable paymentTable = PaymentTable.from(request.getProductId());
 
-        return Payment.builder()
+        Optional<Payment> payment = paymentRepository.findByOrderId(response.getOrderId());
+
+        return payment.orElseGet(() -> Payment.builder()
             .money(paymentTable.getPrice())
             .bookmark(paymentTable.getCount())
             .paymentType(PaymentType.GOOGLE)
-            .receipt(response.getOrderId())
-            .build();
+            .orderId(response.getOrderId())
+            .purchaseToken(request.getPurchaseToken())
+            .build());
+
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/Payment.java
@@ -37,6 +37,10 @@ public class Payment extends BaseEntity {
 
     private String receipt; // 거래 후 받는 영수증 정보
 
+    private String orderId; // 구글 인앱 결제 후 받는 주문 정보
+
+    private String purchaseToken; // 구글 인앱 결제 후 받는 토큰 정보
+
     @Column(columnDefinition = "TEXT")
     private String information; // 서버로부터 받는 json 정보
 

--- a/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/payment/repository/PaymentRepository.java
@@ -8,4 +8,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByReceipt(String receipt);
 
+    Optional<Payment> findByOrderId(String orderId);
+
 }


### PR DESCRIPTION
## 📄 Summary

1. enum 타입으로 `PurchaseState` 추가 (구글 결제 상태)
2. Payment 엔티티에 다음과 같은 필드 추가
  a. orderId - 인앱 상품의 구매와 연결된 주문 ID (for. 환불 처리)
  b. purchaseToken - 구매 토큰 정보 저장 (for. 환불 처리)

>
## 🙋🏻 More

>