### PR TITLE
fix: 학생증 및 거절 필터링 쿼리 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/repository/custom/impl/MemberVerifyRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/custom/impl/MemberVerifyRepositoryCustomImpl.java
@@ -30,17 +30,15 @@ public class MemberVerifyRepositoryCustomImpl implements MemberVerifyRepositoryC
                 .from(memberVerify)
                 .join(member).on(memberVerify.memberId.eq(member.id))
                 .where(
-                        (memberVerify.memberId.in(filteringMemberId))
-                                .and(
-                                        ((member.createdAt.before(twoDaysAgo))
-                                        .and(memberVerify.verifyType.eq(MemberVerifyType.STUDENT_ID))
-                                        .and(memberVerify.verifyStatus.eq(MemberVerifyStatus.SUCCESS)))
-                                                .or((member.createdAt.after(twoDaysAgo)).or(member.createdAt.eq(twoDaysAgo))
-                                                        .and(memberVerify.verifyType.eq(MemberVerifyType.STUDENT_ID)))
-
-                                )
-                )
-                .fetch();
+                        (memberVerify.memberId.in(filteringMemberId)),
+                        (
+                            ((member.createdAt.before(twoDaysAgo))
+                                .and(memberVerify.verifyType.eq(MemberVerifyType.STUDENT_ID))
+                                .and(memberVerify.verifyStatus.eq(MemberVerifyStatus.SUCCESS)))
+                            .or(((member.createdAt.after(twoDaysAgo)).or(member.createdAt.eq(twoDaysAgo)))
+                                .and(memberVerify.verifyType.eq(MemberVerifyType.STUDENT_ID)))
+                        )
+                ).fetch();
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -98,9 +98,10 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                 .from(postcard)
                 .where(
                         postcard.receiveMember.id.in(filteringMemberId),
-                        (postcard.sendMember.id.eq(sendMemberId)
+                        ((postcard.sendMember.id.eq(sendMemberId))
                                 .and(postcard.postcardStatus.eq(PostcardStatus.REFUSED))
-                                .and(postcard.postcardStatusRefusedAt.before(twoWeeksAgo)))
+                                .and(postcard.postcardStatusRefusedAt.before(twoWeeksAgo))
+                        )
                 ).fetch();
     }
 }


### PR DESCRIPTION
## 📄 Summary

> aws 접속하여 로그보고 매칭 필터링을 위한 querydsl 수정했습니다
원하는 조건이 and()에서 일부 빠져서 다시 수정했습니다 

## 🙋🏻 More

>