### PR TITLE
fix, refactor: 매칭 알고리즘 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/repository/MatchExcludedRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/MatchExcludedRepository.java
@@ -1,0 +1,11 @@
+package com.bookbla.americano.domain.matching.repository;
+
+import com.bookbla.americano.domain.matching.repository.entity.MatchExcludedInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MatchExcludedRepository extends JpaRepository<MatchExcludedInfo, Long> {
+
+    Optional<MatchExcludedInfo> findByMemberIdAndExcludedMemberId(Long memberId, Long excludedMemberId);
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/MatchIgnoredRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/MatchIgnoredRepository.java
@@ -1,0 +1,11 @@
+package com.bookbla.americano.domain.matching.repository;
+
+import com.bookbla.americano.domain.matching.repository.entity.MatchIgnoredInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MatchIgnoredRepository extends JpaRepository<MatchIgnoredInfo, Long> {
+
+    Optional<MatchIgnoredInfo> findByMemberIdAndIgnoredMemberIdAndIgnoredMemberBookId(Long memberId, Long ignoredMemberId, Long ignoredMemberBookId);
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/MatchedInfoRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/MatchedInfoRepository.java
@@ -1,11 +1,8 @@
 package com.bookbla.americano.domain.matching.repository;
 
+import com.bookbla.americano.domain.matching.repository.custom.MatchedInfoRepositoryCustom;
 import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-public interface MatchedInfoRepository extends JpaRepository<MatchedInfo, Long> {
-
-    List<MatchedInfo> findAllByMemberMatchingId(Long memberMatchingId);
+public interface MatchedInfoRepository extends JpaRepository<MatchedInfo, Long>, MatchedInfoRepositoryCustom {
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MatchedInfoRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MatchedInfoRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.bookbla.americano.domain.matching.repository.custom;
+
+import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+
+import java.util.List;
+
+public interface MatchedInfoRepositoryCustom {
+
+    List<MatchedInfo> findAllByMemberMatchingId(Long memberMatchingId);
+
+    List<MatchedInfo> getAllByDesc(Long memberMatchingId);
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchedInfoRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchedInfoRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.bookbla.americano.domain.matching.repository.custom.impl;
+
+import com.bookbla.americano.domain.matching.repository.custom.MatchedInfoRepositoryCustom;
+import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+import com.bookbla.americano.domain.member.enums.MemberStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.bookbla.americano.domain.matching.repository.entity.QMatchExcludedInfo.matchExcludedInfo;
+import static com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo.matchIgnoredInfo;
+import static com.bookbla.americano.domain.matching.repository.entity.QMatchedInfo.matchedInfo;
+import static com.bookbla.americano.domain.member.repository.entity.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchedInfoRepositoryImpl implements MatchedInfoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MatchedInfo> findAllByMemberMatchingId(Long memberMatchingId) {
+        return queryFactory
+                .selectFrom(matchedInfo)
+                .innerJoin(member).on(matchedInfo.matchedMemberId.eq(member.id))
+                .innerJoin(matchExcludedInfo).on(matchedInfo.matchedMemberId.ne(matchExcludedInfo.excludedMemberId))
+                .innerJoin(matchIgnoredInfo).on(matchedInfo.matchedMemberId.ne(matchIgnoredInfo.ignoredMemberId))
+                .where(
+                        matchedInfo.memberMatching.id.eq(memberMatchingId),
+                        member.memberStatus.ne(MemberStatus.DELETED),
+                        member.memberStatus.ne(MemberStatus.BLOCKED),
+                        member.memberStatus.ne(MemberStatus.MATCHING_DISABLED),
+                        member.memberStatus.ne(MemberStatus.REPORTED))
+                .orderBy(matchedInfo.similarityWeight.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<MatchedInfo> getAllByDesc(Long memberMatchingId) {
+        return queryFactory
+                .selectFrom(matchedInfo)
+                .where(matchedInfo.memberMatching.id.eq(memberMatchingId))
+                .orderBy(matchedInfo.similarityWeight.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MemberMatchingRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MemberMatchingRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.bookbla.americano.domain.matching.repository.custom.impl;
 
 import com.bookbla.americano.domain.matching.repository.custom.MemberMatchingRepositoryCustom;
 import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+import com.bookbla.americano.domain.matching.repository.entity.QMatchExcludedInfo;
+import com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo;
 import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 import com.bookbla.americano.domain.member.enums.Gender;
 import com.bookbla.americano.domain.member.enums.MemberStatus;
@@ -12,7 +14,6 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.bookbla.americano.domain.member.repository.entity.QMember.member;
@@ -26,22 +27,25 @@ public class MemberMatchingRepositoryImpl implements MemberMatchingRepositoryCus
 
     @Override
     public List<MatchedInfo> getMatchingMembers(MemberRecommendationDto recommendationDto) {
-        Set<Long> excludeMemberIds = recommendationDto.getExcludeMemberIds();
-
         LocalDateTime twoWeeksAgo = LocalDateTime.now().minusDays(14);
+        QMatchExcludedInfo matchExcludedInfo = QMatchExcludedInfo.matchExcludedInfo;
+        QMatchIgnoredInfo matchIgnoredInfo = QMatchIgnoredInfo.matchIgnoredInfo;
 
         return queryFactory
                 .selectDistinct(member.id, memberBook.id)
-                .from(memberBook)
-                .join(member).on(memberBook.member.eq(member))
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .innerJoin(matchExcludedInfo).on(member.id.ne(matchExcludedInfo.excludedMemberId))
+                .innerJoin(matchIgnoredInfo).on(member.id.ne(matchIgnoredInfo.ignoredMemberId))
                 .where(
                         member.id.ne(recommendationDto.getMemberId()),
                         member.memberStatus.ne(MemberStatus.DELETED),
                         member.memberStatus.ne(MemberStatus.MATCHING_DISABLED),
+                        member.memberStatus.ne(MemberStatus.BLOCKED),
+                        member.memberStatus.ne(MemberStatus.REPORTED),
                         member.memberProfile.gender.ne(Gender.valueOf(recommendationDto.getMemberGender())),
-                        member.lastUsedAt.coalesce(LocalDate.parse("1900-01-01").atStartOfDay()).after(twoWeeksAgo),
-                        member.id.notIn(excludeMemberIds)
-                ).fetch()
+                        member.lastUsedAt.coalesce(LocalDate.parse("1900-01-01").atStartOfDay()).after(twoWeeksAgo))
+                .fetch()
                 .stream()
                 .map(tuple -> MatchedInfo.builder()
                         .matchedMemberId(tuple.get(member.id))

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchExcludedInfo.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchExcludedInfo.java
@@ -1,0 +1,32 @@
+package com.bookbla.americano.domain.matching.repository.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchExcludedInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Long excludedMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_matching_id")
+    private MemberMatching memberMatching;
+
+    public static MatchExcludedInfo of(Long memberId, Long excludedMemberId) {
+        return MatchExcludedInfo.builder()
+                .memberId(memberId)
+                .excludedMemberId(excludedMemberId)
+                .build();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchIgnoredInfo.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchIgnoredInfo.java
@@ -1,0 +1,35 @@
+package com.bookbla.americano.domain.matching.repository.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MatchIgnoredInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Long ignoredMemberId;
+
+    private Long ignoredMemberBookId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_matching_id")
+    private MemberMatching memberMatching;
+
+    public static MatchIgnoredInfo from(Long memberId, Long ignoredMemberId, Long ignoredMemberBookId) {
+        return MatchIgnoredInfo.builder()
+                .memberId(memberId)
+                .ignoredMemberId(ignoredMemberId)
+                .ignoredMemberBookId(ignoredMemberBookId)
+                .build();
+    }
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchedInfo.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchedInfo.java
@@ -26,16 +26,8 @@ public class MatchedInfo {
     @JoinColumn(name = "member_matching_id")
     private MemberMatching memberMatching;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_book_id")
-    private MemberMatching ignoredMemberAndMemberBook;
-
     public void accumulateSimilarityWeight(Double similarityWeight) {
         this.similarityWeight += similarityWeight;
-    }
-
-    public void updateMemberMatching(MemberMatching memberMatching) {
-        this.memberMatching = memberMatching;
     }
 
     public static MatchedInfo from(Long matchedMemberId, Long matchedMemberBookId) {

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MemberMatching.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MemberMatching.java
@@ -1,15 +1,11 @@
 package com.bookbla.americano.domain.matching.repository.entity;
 
-import com.bookbla.americano.base.exception.BaseException;
-import com.bookbla.americano.domain.matching.exception.MemberMatchingExceptionType;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -30,50 +26,18 @@ public class MemberMatching {
     @OneToMany(mappedBy = "memberMatching")
     private List<MatchedInfo> matched; // 필터링을 거친 매칭된 회원 저장
 
-    @Builder.Default
-    @ElementCollection
-    @CollectionTable(name = "member_match_excluded", joinColumns = @JoinColumn(name = "member_matching_id"))
-    private Set<Long> excluded = new HashSet<>(); // 매칭에서 제외된 회원
+    @OneToMany(mappedBy = "memberMatching")
+    private List<MatchExcludedInfo> excluded; // 매칭에서 제외된 회원
 
     @OneToMany(mappedBy = "memberMatching")
-    private List<MatchedInfo> ignoredMemberAndBook; // 매칭에서 제외된 회원
-
-    // TODO: matched 저장 쿼리 나가는지 확인
-    public void saveAndUpdateMatched(List<MatchedInfo> matchingMembers) {
-        matchingMembers.forEach(matchedInfo -> matchedInfo.updateMemberMatching(this));
-        this.matched = matchingMembers;
-    }
-
-    public void sortMatched() {
-        // 가중치 큰 순으로 정렬
-        matched.sort((matched1, matched2) ->
-                Double.compare(matched2.getSimilarityWeight(), matched1.getSimilarityWeight()));
-    }
-
-    public void addExcludedMember(Long memberId) {
-        excluded.add(memberId);
-    }
-
-    public void addIgnoredMemberAndBook(Long memberId, Long memberBookId) {
-        ignoredMemberAndBook.add(MatchedInfo.from(memberId, memberBookId));
-    }
+    private List<MatchIgnoredInfo> ignoredMemberAndBook; // 매칭에서 제외된 회원 + 책
 
     public static MemberMatching of(Member member) {
         return MemberMatching.builder()
                 .member(member)
                 .matched(new ArrayList<>())
+                .excluded(new ArrayList<>())
                 .ignoredMemberAndBook(new ArrayList<>())
                 .build();
-    }
-
-    public MatchedInfo popMostPriorityMatched() {
-        if (matched.isEmpty()) {
-            throw new BaseException(MemberMatchingExceptionType.MATCHING_MEMBER_DOESNT_EXIST);
-        }
-
-        MatchedInfo mostPriorityMatched = matched.get(0);
-        matched.remove(0);
-
-        return mostPriorityMatched;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingAlgorithmFilter.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingAlgorithmFilter.java
@@ -7,6 +7,7 @@ import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -21,12 +22,14 @@ import java.util.List;
  * 6. 다른 학교 흡연여부 동일
  */
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberMatchingAlgorithmFilter {
 
     private final MemberRepository memberRepository;
     private final MemberBookRepository memberBookRepository;
 
+    // TODO: 쿼리 최적화하기
     public void memberMatchingAlgorithmFiltering(Member member, List<MatchedInfo> matchingMembers) {
 
         for (MatchedInfo matchedInfo : matchingMembers) {

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingFilter.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingFilter.java
@@ -7,12 +7,14 @@ import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberMatchingFilter {
 

--- a/src/main/java/com/bookbla/americano/domain/matching/service/dto/MemberRecommendationDto.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/dto/MemberRecommendationDto.java
@@ -5,8 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.Set;
-
 @Getter
 @Builder
 @AllArgsConstructor
@@ -14,13 +12,11 @@ public class MemberRecommendationDto {
 
     private Long memberId;
     private String memberGender;
-    private Set<Long> excludeMemberIds;
 
-    public static MemberRecommendationDto from(Member member, Set<Long> excludeMemberIds) {
+    public static MemberRecommendationDto from(Member member) {
         return MemberRecommendationDto.builder()
                 .memberId(member.getId())
                 .memberGender(member.getMemberProfile().getGender().name())
-                .excludeMemberIds(excludeMemberIds)
                 .build();
     }
 }


### PR DESCRIPTION
## 📄 Summary

기존 MatchedInfo 에 모든 필터링된 매칭 정보를 저장하는 방식은 유저가 증가할수록 기하급수적으로 디비에 부담이 갈 거라 생각했습니다

MemberMatching 엔티티를 필두로

1. 필터링과 알고리즘을 거친 매칭 정보를 저장하는 `MatchedInfo`
2. 추천 아이디와 책을 무시하는 `MatchIgnoredInfo`
3. 추천 아이디를 무시하는 `MatchExcludedInfo`

로 분리했습니다.

이에 따른 쿼리 및 dto 단에도 수정이 생겼습니다