### PR TITLE
feat: 엽서 보내는 회원의 학생증 인증 상태 검증 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/exception/MemberProfileExceptionType.java
+++ b/src/main/java/com/bookbla/americano/domain/member/exception/MemberProfileExceptionType.java
@@ -14,6 +14,7 @@ public enum MemberProfileExceptionType implements ExceptionType {
     ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "member_profile_03", "이미 사용중인 닉네임입니다."),
     CONTAIN_BAD_WORDS(HttpStatus.BAD_REQUEST, "member_profile_04", "사용할 수 없는 단어가(비속어, 북블라 등) 포함되어있습니다."),
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "member_profile_05", "프로필이 등록되지 않은 회원입니다."),
+    STUDENT_ID_NOT_VALID(HttpStatus.NOT_FOUND, "member_profile_06", "학생증이 인증되지 않은 회원입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/Member.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/Member.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.bookbla.americano.domain.member.enums.StudentIdImageStatus.DONE;
+
 @Entity
 @Getter
 @Builder
@@ -208,6 +210,12 @@ public class Member extends BaseEntity {
     public void validateStyleRegistered() {
         if (this.memberStyle != null) {
             throw new BaseException(MemberExceptionType.STYLE_ALREADY_REGISTERED);
+        }
+    }
+
+    public void validateStudentIdStatusRegistered() {
+        if (this.memberProfile.getStudentIdImageStatus() != DONE) {
+            throw new BaseException(MemberProfileExceptionType.STUDENT_ID_NOT_VALID);
         }
     }
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -8,10 +8,7 @@ import com.bookbla.americano.domain.matching.repository.entity.MatchExcludedInfo
 import com.bookbla.americano.domain.matching.repository.entity.MatchIgnoredInfo;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberBookReadResponses;
 import com.bookbla.americano.domain.member.exception.MemberExceptionType;
-import com.bookbla.americano.domain.member.repository.MemberBlockRepository;
-import com.bookbla.americano.domain.member.repository.MemberBookRepository;
-import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
-import com.bookbla.americano.domain.member.repository.MemberRepository;
+import com.bookbla.americano.domain.member.repository.*;
 import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberBook;
 import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
@@ -59,6 +56,10 @@ public class PostcardService {
     private final MatchIgnoredRepository matchIgnoredRepository;
 
     public SendPostcardResponse send(Long memberId, SendPostcardRequest request) {
+        // 엽서 보내는 회원의 학생증 상태 검증
+        Member member = memberRepository.getByIdOrThrow(memberId);
+        member.validateStudentIdStatusRegistered();
+
         MemberBookmark memberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(
                         memberId)
                 .orElseThrow(
@@ -74,7 +75,6 @@ public class PostcardService {
         sentPostcards.forEach(Postcard::validateSendPostcard);
         PostcardStatus status = PostcardStatus.PENDING;
 
-        Member member = memberRepository.getByIdOrThrow(memberId);
         Member targetMember = memberRepository.getByIdOrThrow(request.getReceiveMemberId());
         memberBookmark.sendPostcard();
 


### PR DESCRIPTION
## 📄 Summary

> 최초 가입 후 학생증이 인증되지 않은 상태에서 엽서를 보낼 수 없는 로직 추가

## 🙋🏻 More

> 