### PR TITLE
refactor: memberId, memberBookId 필터링 -> memberId 필터링 후 memberId에 해당되는 memberBookId 필터링

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/repository/MatchIgnoredRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/MatchIgnoredRepository.java
@@ -1,11 +1,12 @@
 package com.bookbla.americano.domain.matching.repository;
 
+import com.bookbla.americano.domain.matching.repository.custom.MatchIgnoredRepositoryCustom;
 import com.bookbla.americano.domain.matching.repository.entity.MatchIgnoredInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MatchIgnoredRepository extends JpaRepository<MatchIgnoredInfo, Long> {
+public interface MatchIgnoredRepository extends JpaRepository<MatchIgnoredInfo, Long>, MatchIgnoredRepositoryCustom {
 
     Optional<MatchIgnoredInfo> findByMemberIdAndIgnoredMemberIdAndIgnoredMemberBookId(Long memberId, Long ignoredMemberId, Long ignoredMemberBookId);
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MatchIgnoredRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MatchIgnoredRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.bookbla.americano.domain.matching.repository.custom;
+
+import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
+
+import java.util.List;
+
+public interface MatchIgnoredRepositoryCustom {
+
+    List<MatchedInfo> getIgnoredMemberIdsAndIgnoredMemberBookIdByMemberId(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto);
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MatchedInfoRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MatchedInfoRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.bookbla.americano.domain.matching.repository.custom;
 
 import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 
 import java.util.List;
 
@@ -9,6 +10,12 @@ public interface MatchedInfoRepositoryCustom {
     List<MatchedInfo> findAllByMemberMatchingId(Long memberMatchingId);
 
     List<MatchedInfo> getAllByDesc(Long memberMatchingId);
+
+    // 모든 매칭 추천 회원 + 회원 책 정보
+    List<MatchedInfo> getAllMatches(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto);
+
+    // 최종 필터링한 매칭 추천 회원 + 회원 책 정보
+    List<MatchedInfo> getFinalFilteredMatches(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto);
 
     long deleteByMemberMatchingId(Long memberMatchingId);
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MemberMatchingRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MemberMatchingRepositoryCustom.java
@@ -1,17 +1,10 @@
 package com.bookbla.americano.domain.matching.repository.custom;
 
-import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
 import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 
 import java.util.List;
 
 public interface MemberMatchingRepositoryCustom {
 
-    List<Long> getMatchingMemberIds(MemberRecommendationDto memberRecommendationDto);
-
-    // 모든 매칭 추천 회원 + 회원 책 정보
-    List<MatchedInfo> getAllMatching(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto);
-
-    // 최종 필터링한 매칭 추천 회원 + 회원 책 정보
-    List<MatchedInfo> getMatchingInfo(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto);
+    List<Long> getMinimumConstraintMemberIds(MemberRecommendationDto memberRecommendationDto);
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MemberMatchingRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/MemberMatchingRepositoryCustom.java
@@ -7,5 +7,11 @@ import java.util.List;
 
 public interface MemberMatchingRepositoryCustom {
 
-    List<MatchedInfo> getMatchingMembers(MemberRecommendationDto memberRecommendationDto);
+    List<Long> getMatchingMemberIds(MemberRecommendationDto memberRecommendationDto);
+
+    // 모든 매칭 추천 회원 + 회원 책 정보
+    List<MatchedInfo> getAllMatching(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto);
+
+    // 최종 필터링한 매칭 추천 회원 + 회원 책 정보
+    List<MatchedInfo> getMatchingInfo(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto);
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchIgnoredRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchIgnoredRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.bookbla.americano.domain.matching.repository.custom.impl;
+
+import com.bookbla.americano.domain.matching.repository.custom.MatchIgnoredRepositoryCustom;
+import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo.matchIgnoredInfo;
+import static com.bookbla.americano.domain.member.repository.entity.QMember.member;
+import static com.bookbla.americano.domain.member.repository.entity.QMemberBook.memberBook;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchIgnoredRepositoryImpl implements MatchIgnoredRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MatchedInfo> getIgnoredMemberIdsAndIgnoredMemberBookIdByMemberId(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto) {
+        return queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .leftJoin(matchIgnoredInfo).on(member.id.eq(matchIgnoredInfo.ignoredMemberId)
+                        .and(memberBook.id.eq(matchIgnoredInfo.ignoredMemberBookId)))
+                .where(matchIgnoredInfo.memberId.eq(memberRecommendationDto.getMemberId()))
+                .fetch()
+                .stream()
+                .map(tuple -> MatchedInfo.from(memberRecommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), memberRecommendationDto.getMemberMatching()))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchedInfoRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchedInfoRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.matching.repository.custom.impl;
 
 import com.bookbla.americano.domain.matching.repository.custom.MatchedInfoRepositoryCustom;
 import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
+import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 import com.bookbla.americano.domain.member.enums.MemberStatus;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -9,11 +10,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.bookbla.americano.domain.matching.repository.entity.QMatchExcludedInfo.matchExcludedInfo;
 import static com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo.matchIgnoredInfo;
 import static com.bookbla.americano.domain.matching.repository.entity.QMatchedInfo.matchedInfo;
 import static com.bookbla.americano.domain.member.repository.entity.QMember.member;
+import static com.bookbla.americano.domain.member.repository.entity.QMemberBook.memberBook;
 
 @Repository
 @RequiredArgsConstructor
@@ -47,6 +50,54 @@ public class MatchedInfoRepositoryImpl implements MatchedInfoRepositoryCustom {
                 .where(matchedInfo.memberMatching.id.eq(memberMatchingId))
                 .orderBy(matchedInfo.similarityWeight.desc())
                 .fetch();
+    }
+
+    @Override
+    public List<MatchedInfo> getAllMatches(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto) {
+        return queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .where(member.id.in(matchingMemberIds),
+                        memberBook.isDeleted.isFalse())
+                .fetch()
+                .stream()
+                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<MatchedInfo> getFinalFilteredMatches(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto) {
+        // 모든 매칭 정보 ( member_id + member_book_id )
+        List<MatchedInfo> matches = queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .where(member.id.in(matchingMemberIds),
+                        memberBook.isDeleted.isFalse())
+                .fetch()
+                .stream()
+                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
+                .collect(Collectors.toList());
+
+        // 무시된 정보
+        List<MatchedInfo> filteredMatches = queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .leftJoin(matchIgnoredInfo).on(member.id.eq(matchIgnoredInfo.ignoredMemberId)
+                        .and(memberBook.id.eq(matchIgnoredInfo.ignoredMemberBookId)))
+                .where(matchIgnoredInfo.memberId.eq(recommendationDto.getMemberId()))
+                .fetch()
+                .stream()
+                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
+                .collect(Collectors.toList());
+
+        // 모든 매칭 정보 - 무시된 정보
+        return matches.stream()
+                .filter(match -> filteredMatches.stream()
+                        .noneMatch(filteredMatch -> filteredMatch.getMatchedMemberId().equals(match.getMatchedMemberId())))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MemberMatchingRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MemberMatchingRepositoryImpl.java
@@ -3,13 +3,9 @@ package com.bookbla.americano.domain.matching.repository.custom.impl;
 import com.bookbla.americano.domain.matching.repository.custom.MemberMatchingRepositoryCustom;
 import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
 import com.bookbla.americano.domain.matching.repository.entity.QMatchExcludedInfo;
-import com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo;
 import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 import com.bookbla.americano.domain.member.enums.Gender;
 import com.bookbla.americano.domain.member.enums.MemberStatus;
-import com.querydsl.core.Tuple;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -19,7 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.bookbla.americano.domain.matching.repository.entity.QMatchedInfo.matchedInfo;
+import static com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo.matchIgnoredInfo;
 import static com.bookbla.americano.domain.member.repository.entity.QMember.member;
 import static com.bookbla.americano.domain.member.repository.entity.QMemberBook.memberBook;
 
@@ -30,27 +26,71 @@ public class MemberMatchingRepositoryImpl implements MemberMatchingRepositoryCus
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<MatchedInfo> getMatchingMembers(MemberRecommendationDto recommendationDto) {
+    public List<Long> getMatchingMemberIds(MemberRecommendationDto recommendationDto) {
         LocalDateTime twoWeeksAgo = LocalDateTime.now().minusDays(14);
         QMatchExcludedInfo matchExcludedInfo = QMatchExcludedInfo.matchExcludedInfo;
 
         return queryFactory
-                .selectDistinct(member.id, memberBook.id)
+                .selectDistinct(member.id)
                 .from(member)
-                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
                 .leftJoin(matchExcludedInfo).on(member.id.eq(matchExcludedInfo.excludedMemberId))
                 .where(
                         matchExcludedInfo.memberId.ne(recommendationDto.getMemberId()),
-                        memberBook.isDeleted.isFalse(),
                         member.memberStatus.ne(MemberStatus.DELETED),
                         member.memberStatus.ne(MemberStatus.MATCHING_DISABLED),
                         member.memberStatus.ne(MemberStatus.REPORTED),
                         member.memberProfile.gender.ne(Gender.valueOf(recommendationDto.getMemberGender())),
                         member.lastUsedAt.coalesce(LocalDate.parse("1900-01-01").atStartOfDay()).after(twoWeeksAgo)
                 )
+                .fetch();
+    }
+
+    @Override
+    public List<MatchedInfo> getAllMatching(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto) {
+        return queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .where(member.id.in(matchingMemberIds),
+                        memberBook.isDeleted.isFalse())
                 .fetch()
                 .stream()
                 .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<MatchedInfo> getMatchingInfo(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto) {
+        // 모든 매칭 정보 ( member_id + member_book_id )
+        List<MatchedInfo> matches = queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .where(member.id.in(matchingMemberIds),
+                        memberBook.isDeleted.isFalse())
+                .fetch()
+                .stream()
+                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
+                .collect(Collectors.toList());
+
+        // 무시된 정보
+        List<MatchedInfo> filteredMatches = queryFactory
+                .select(member.id, memberBook.id)
+                .from(member)
+                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
+                .leftJoin(matchIgnoredInfo).on(member.id.eq(matchIgnoredInfo.ignoredMemberId)
+                        .and(memberBook.id.eq(matchIgnoredInfo.ignoredMemberBookId)))
+                .where(matchIgnoredInfo.memberId.eq(recommendationDto.getMemberId()))
+                .fetch()
+                .stream()
+                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
+                .collect(Collectors.toList());
+
+        // 모든 매칭 정보 - 무시된 정보
+        return matches.stream()
+                .filter(match -> filteredMatches.stream()
+                        .noneMatch(filteredMatch -> filteredMatch.getMatchedMemberId().equals(match.getMatchedMemberId())))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MemberMatchingRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MemberMatchingRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.bookbla.americano.domain.matching.repository.custom.impl;
 
 import com.bookbla.americano.domain.matching.repository.custom.MemberMatchingRepositoryCustom;
-import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
 import com.bookbla.americano.domain.matching.repository.entity.QMatchExcludedInfo;
 import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 import com.bookbla.americano.domain.member.enums.Gender;
@@ -13,11 +12,8 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static com.bookbla.americano.domain.matching.repository.entity.QMatchIgnoredInfo.matchIgnoredInfo;
 import static com.bookbla.americano.domain.member.repository.entity.QMember.member;
-import static com.bookbla.americano.domain.member.repository.entity.QMemberBook.memberBook;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,7 +22,7 @@ public class MemberMatchingRepositoryImpl implements MemberMatchingRepositoryCus
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Long> getMatchingMemberIds(MemberRecommendationDto recommendationDto) {
+    public List<Long> getMinimumConstraintMemberIds(MemberRecommendationDto recommendationDto) {
         LocalDateTime twoWeeksAgo = LocalDateTime.now().minusDays(14);
         QMatchExcludedInfo matchExcludedInfo = QMatchExcludedInfo.matchExcludedInfo;
 
@@ -43,54 +39,6 @@ public class MemberMatchingRepositoryImpl implements MemberMatchingRepositoryCus
                         member.lastUsedAt.coalesce(LocalDate.parse("1900-01-01").atStartOfDay()).after(twoWeeksAgo)
                 )
                 .fetch();
-    }
-
-    @Override
-    public List<MatchedInfo> getAllMatching(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto) {
-        return queryFactory
-                .select(member.id, memberBook.id)
-                .from(member)
-                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
-                .where(member.id.in(matchingMemberIds),
-                        memberBook.isDeleted.isFalse())
-                .fetch()
-                .stream()
-                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public List<MatchedInfo> getMatchingInfo(List<Long> matchingMemberIds, MemberRecommendationDto recommendationDto) {
-        // 모든 매칭 정보 ( member_id + member_book_id )
-        List<MatchedInfo> matches = queryFactory
-                .select(member.id, memberBook.id)
-                .from(member)
-                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
-                .where(member.id.in(matchingMemberIds),
-                        memberBook.isDeleted.isFalse())
-                .fetch()
-                .stream()
-                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
-                .collect(Collectors.toList());
-
-        // 무시된 정보
-        List<MatchedInfo> filteredMatches = queryFactory
-                .select(member.id, memberBook.id)
-                .from(member)
-                .innerJoin(memberBook).on(member.id.eq(memberBook.member.id))
-                .leftJoin(matchIgnoredInfo).on(member.id.eq(matchIgnoredInfo.ignoredMemberId)
-                        .and(memberBook.id.eq(matchIgnoredInfo.ignoredMemberBookId)))
-                .where(matchIgnoredInfo.memberId.eq(recommendationDto.getMemberId()))
-                .fetch()
-                .stream()
-                .map(tuple -> MatchedInfo.from(recommendationDto.getMemberId(), tuple.get(member.id), tuple.get(memberBook.id), recommendationDto.getMemberMatching()))
-                .collect(Collectors.toList());
-
-        // 모든 매칭 정보 - 무시된 정보
-        return matches.stream()
-                .filter(match -> filteredMatches.stream()
-                        .noneMatch(filteredMatch -> filteredMatch.getMatchedMemberId().equals(match.getMatchedMemberId())))
-                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingFilter.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingFilter.java
@@ -1,7 +1,7 @@
 package com.bookbla.americano.domain.matching.service;
 
 import com.bookbla.americano.domain.matching.repository.MatchIgnoredRepository;
-import com.bookbla.americano.domain.matching.repository.MemberMatchingRepository;
+import com.bookbla.americano.domain.matching.repository.MatchedInfoRepository;
 import com.bookbla.americano.domain.matching.repository.entity.MatchedInfo;
 import com.bookbla.americano.domain.matching.service.dto.MemberRecommendationDto;
 import com.bookbla.americano.domain.member.repository.MemberBlockRepository;
@@ -21,7 +21,7 @@ public class MemberMatchingFilter {
     private final PostcardRepository postcardRepository;
     private final MemberBlockRepository memberBlockRepository;
     private final MatchIgnoredRepository matchIgnoredRepository;
-    private final MemberMatchingRepository memberMatchingRepository;
+    private final MatchedInfoRepository matchedInfoRepository;
 
     /**
      * 엽서 거절 조건 필터링
@@ -55,7 +55,7 @@ public class MemberMatchingFilter {
      * 무시한 회원 필터링
      */
     public List<MatchedInfo> memberIgnoredFiltering(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto) {
-        List<MatchedInfo> matches = memberMatchingRepository.getAllMatching(matchingMemberIds, memberRecommendationDto);
+        List<MatchedInfo> matches = matchedInfoRepository.getAllMatches(matchingMemberIds, memberRecommendationDto);
         List<MatchedInfo> filteredMatches = matchIgnoredRepository.getIgnoredMemberIdsAndIgnoredMemberBookIdByMemberId(matchingMemberIds, memberRecommendationDto);
 
         return matches.stream()
@@ -69,6 +69,6 @@ public class MemberMatchingFilter {
      * 필터링 최종 결과
      */
     public List<MatchedInfo> finalFiltering(List<Long> matchingMemberIds, MemberRecommendationDto memberRecommendationDto) {
-         return memberMatchingRepository.getMatchingInfo(matchingMemberIds,memberRecommendationDto);
+         return matchedInfoRepository.getFinalFilteredMatches(matchingMemberIds,memberRecommendationDto);
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
@@ -62,15 +62,18 @@ public class MemberMatchingService {
 
         MemberRecommendationDto memberRecommendationDto = MemberRecommendationDto.from(member, memberMatching);
 
-        List<MatchedInfo> recommendedMembers = memberMatchingRepository
-                .getMatchingMembers(memberRecommendationDto);
-        log.info("최소 조건으로 추출한 추천 회원 수: {}", recommendedMembers.size());
+        List<Long> recommendedMemberIds = memberMatchingRepository.getMatchingMemberIds(memberRecommendationDto);
+        log.info("최소 조건(제외 및 회원 상태)으로 추출한 추천 회원 ID 수: {}", recommendedMemberIds.size());
 
-        recommendedMembers = memberMatchingFilter.memberBlockedFiltering(member.getId(), recommendedMembers);
-        log.info("차단한 회원 필터링 후 추천 회원 수: {}", recommendedMembers.size());
+        recommendedMemberIds = memberMatchingFilter.memberBlockedFiltering(member.getId(), recommendedMemberIds);
+        log.info("차단한 회원 필터링 후 추천 회원 ID 수: {}", recommendedMemberIds.size());
 
-        recommendedMembers = memberMatchingFilter.memberRefusedAtFiltering(member.getId(), recommendedMembers);
-        log.info("엽서 거절 필터링 후 추천 회원 수: {}", recommendedMembers.size());
+        recommendedMemberIds = memberMatchingFilter.memberRefusedAtFiltering(member.getId(), recommendedMemberIds);
+        log.info("엽서 거절 필터링 후 추천 회원 ID 수: {}", recommendedMemberIds.size());
+
+//        List<MatchedInfo> recommendedMembers = memberMatchingFilter.memberIgnoredFiltering(recommendedMemberIds, memberRecommendationDto);
+        List<MatchedInfo> recommendedMembers = memberMatchingFilter.finalFiltering(recommendedMemberIds, memberRecommendationDto);
+        log.info("무시한 회원 필터링 후 ❗️최종 추천 수: {}", recommendedMembers.size());
 
         log.info("알고리즘 가중치 적용 쿼리 ⬇️⬇️⬇️");
         recommendedMembers = memberMatchingAlgorithmFilter.memberMatchingAlgorithmFiltering(member, recommendedMembers);

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
@@ -62,7 +62,7 @@ public class MemberMatchingService {
 
         MemberRecommendationDto memberRecommendationDto = MemberRecommendationDto.from(member, memberMatching);
 
-        List<Long> recommendedMemberIds = memberMatchingRepository.getMatchingMemberIds(memberRecommendationDto);
+        List<Long> recommendedMemberIds = memberMatchingRepository.getMinimumConstraintMemberIds(memberRecommendationDto);
         log.info("최소 조건(제외 및 회원 상태)으로 추출한 추천 회원 ID 수: {}", recommendedMemberIds.size());
 
         recommendedMemberIds = memberMatchingFilter.memberBlockedFiltering(member.getId(), recommendedMemberIds);

--- a/src/main/java/com/bookbla/americano/domain/member/repository/custom/MemberBlockRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/custom/MemberBlockRepositoryCustom.java
@@ -1,10 +1,9 @@
 package com.bookbla.americano.domain.member.repository.custom;
 
 import java.util.List;
-import java.util.Set;
 
 public interface MemberBlockRepositoryCustom {
 
     // 앱 사용자가 차단한 회원
-    List<Long> getBlockedMemberIdsByBlockerMemberId(Long MemberId, Set<Long> matchingMembers);
+    List<Long> getBlockedMemberIdsByBlockerMemberId(Long MemberId, List<Long> matchingMemberIds);
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/custom/impl/MemberBlockRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/custom/impl/MemberBlockRepositoryImpl.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 
 import static com.bookbla.americano.domain.member.repository.entity.QMemberBlock.memberBlock;
 
@@ -17,13 +16,13 @@ public class MemberBlockRepositoryImpl implements MemberBlockRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Long> getBlockedMemberIdsByBlockerMemberId(Long memberId, Set<Long> matchingMembers) {
+    public List<Long> getBlockedMemberIdsByBlockerMemberId(Long memberId, List<Long> matchingMemberIds) {
 
         return queryFactory
                 .select(memberBlock.blockedMember.id)
                 .from(memberBlock)
                 .where(memberBlock.blockerMember.id.eq(memberId),
-                        memberBlock.blockedMember.id.in(matchingMembers)
+                        memberBlock.blockedMember.id.in(matchingMemberIds)
                 ).fetch();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/PostcardRepositoryCustom.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/PostcardRepositoryCustom.java
@@ -1,13 +1,10 @@
 package com.bookbla.americano.domain.postcard.repository.custom;
 
-import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
-
 import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
 
 import java.util.List;
-import java.util.Set;
 
 public interface PostcardRepositoryCustom {
 
@@ -17,5 +14,5 @@ public interface PostcardRepositoryCustom {
 
     List<Postcard> refuseExpiredPostcard();
 
-    List<Long> getReceiveIdsRefusedAt(Long sendMemberId, Set<Long> filteringMemberId);
+    List<Long> getReceiveIdsRefusedAt(Long sendMemberId, List<Long> filteringMemberId);
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -8,7 +8,6 @@ import com.bookbla.americano.domain.postcard.repository.entity.QPostcard;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardFromResponse;
 import com.bookbla.americano.domain.postcard.service.dto.response.PostcardToResponse;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 
 import static com.bookbla.americano.domain.postcard.repository.entity.QPostcard.postcard;
 
@@ -90,7 +88,7 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
     }
 
     @Override
-    public List<Long> getReceiveIdsRefusedAt(Long sendMemberId, Set<Long> filteringMemberId) {
+    public List<Long> getReceiveIdsRefusedAt(Long sendMemberId, List<Long> filteringMemberId) {
 
         LocalDateTime twoWeeksAgo = LocalDateTime.now().minusWeeks(2);
 


### PR DESCRIPTION
## 📄 Summary

> 홈에 추천해줄 memberId를 단계별로 필터링 후 필터링된 memberId의 memberBookId를 모두 뽑아 MatchIgnoredInfo를 필터링하여 최종적으로 memberId, memberBookId를 뽑아냄
=> MatchIgnoredInfo에서 memberId, memberBookId를 필터링하기 복잡했던 문제 해결 ✔️
>
> 1️⃣ ) 최소 조건: 제외 및 회원 상태 으로 추출한 추천 memberIds
2️⃣ ) 차단한 회원 필터링 후 추천 memberIds
3️⃣ ) 엽서 거절 필터링 후 추천 memberIds
4️⃣ ) 3️⃣을 통해 나온 memberIds에 해당하는 모든 memberBookIds - MatchIgnoredInfo에 있는 memberId, memberBookId

## 🙋🏻 More

> 4️⃣ 의 경우 
> 1. "memberMatchingRepository.getAllMatching() 에서matchIgnoredRepository.getIgnoredMemberIdsAndIgnoredMemberBookIdByMemberId()를 제거하는 방법"으로 memberMatchingFilter의 memberIgnoredFiltering()에서 두개를 사용해서 로직 구현 
> 2. 위의 두 레포를 가져와 로직 구현한 부분을 하나로 합친 memberMatchingRepository.getMatchingInfo()를 만들어
memberMatchingFilter의 finalFiltering()에서 로직 구현
**Q. 현재 1번은 주석 처리, 2번으로 구현되어있는데 유지보수나 유연성때문에 1번을 남겨둔 상태.. 둘 중에 어떤것을 사용하면 좋을지..**

> 3️⃣ 의 경우
특정 회원의 엽서 거절시 특정 회원 id가 매칭에서 제외되는데 기획상 거절 당한 책은 2주뒤에 나오고 그 회원의 다른 책은 계속 떠야하므로 쿼리 수정이 필요할것으로 보임,,,,,,,,,,,