### PR TITLE
fix: refresh시 pop할때 발생하는 에러

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchedInfoRepositoryImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/custom/impl/MatchedInfoRepositoryImpl.java
@@ -29,13 +29,13 @@ public class MatchedInfoRepositoryImpl implements MatchedInfoRepositoryCustom {
         return queryFactory
                 .selectFrom(matchedInfo)
                 .innerJoin(member).on(matchedInfo.matchedMemberId.eq(member.id))
-                .leftJoin(matchExcludedInfo).on(matchedInfo.matchedMemberId.eq(matchExcludedInfo.excludedMemberId))
-                .leftJoin(matchIgnoredInfo).on(matchedInfo.matchedMemberId.eq(matchIgnoredInfo.ignoredMemberId))
+//                .leftJoin(matchExcludedInfo).on(matchedInfo.matchedMemberId.eq(matchExcludedInfo.excludedMemberId))
+//                .leftJoin(matchIgnoredInfo).on(matchedInfo.matchedMemberId.eq(matchIgnoredInfo.ignoredMemberId))
                 .where(
                         matchedInfo.memberMatching.id.eq(memberMatchingId),
-                        matchExcludedInfo.excludedMemberId.ne(matchedInfo.memberId)
-                                .or(matchIgnoredInfo.ignoredMemberId.isNull()),
-                        matchIgnoredInfo.ignoredMemberId.ne(matchedInfo.memberId),
+//                        matchExcludedInfo.excludedMemberId.ne(matchedInfo.memberId)
+//                                .or(matchIgnoredInfo.ignoredMemberId.isNull()),
+//                        matchIgnoredInfo.ignoredMemberId.ne(matchedInfo.memberId),
                         member.memberStatus.ne(MemberStatus.DELETED),
                         member.memberStatus.ne(MemberStatus.MATCHING_DISABLED),
                         member.memberStatus.ne(MemberStatus.REPORTED))


### PR DESCRIPTION
## 📄 Summary

> @khyu2 홈매칭 쿼리 수정으로 인해 회원 상태변경 및 신고, 무시에 따른 matchedInfo에 반영되어 pop되는 부분도 다시 수정해야합니다

## 🙋🏻 More

>