### PR TITLE
fix: 매칭 알고리즘 가중치 세분화

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/service/dto/MatchingSimilarityWeightConstants.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/dto/MatchingSimilarityWeightConstants.java
@@ -3,11 +3,16 @@ package com.bookbla.americano.domain.matching.service.dto;
 public class MatchingSimilarityWeightConstants {
 
     public static final double SAME_SCHOOL_SAME_BOOK = 1.0;
-    public static final double OTHER_SCHOOL_SAME_BOOK = 0.9;
-    public static final double SAME_SCHOOL_SAME_AUTHOR = 0.8;
-    public static final double OTHER_SCHOOL_SAME_AUTHOR = 0.7;
-    public static final double SAME_SCHOOL_SAME_SMOKING = 0.6;
-    public static final double OTHER_SCHOOL_SAME_SMOKING = 0.5;
+    public static final double SAME_SCHOOL_SAME_AUTHOR = 0.4;
+
+    public static final double GREAT_REVIEW = 0.5; // 60자 이상
+    public static final double GOOD_REVIEW = 0.2; // 30자 이상
+
+    public static final double SAME_SCHOOL_SAME_SMOKING = 0.3;
+    public static final double SAME_SMOKING = 0.2;
     public static final double SAME_SCHOOL = 0.2;
-    public static final double SAME_BOOK = 0.1;
+    public static final double SAME_BOOK = 0.6;
+    public static final double SAME_AUTHOR = 0.1;
+
+    public static final double PEER = 0.4;
 }


### PR DESCRIPTION
## 📄 Summary

> 회원가입 시 받는 정보를 최대한 활용하도록 알고리즘 매칭 가중치를 세분화했습니다
## 🙋🏻 More

기본적인 흐름입니다

### 가중치
같은 책: 0.6 (매우 중요한 항목)
리뷰 글자수 60자 이상: 0.5 (매우 중요한 항목)
나이 차이 3 이하: 0.4 (중요 항목)
같은 학교: 0.3 (중간 중요 항목)
흡연 여부 일치: 0.2 (중간 중요 항목)
같은 저자: 0.1 (덜 중요한 항목)
나이 차이 3 초과: 0.1 (덜 중요한 항목)

### 현재 플로우
같은 학교 같은 책: 1.0
같은 학교 같은 저자: 0.4
같은 학교 : 0.2
같은 학교 흡연 여부 동일: 0.3

다른 학교 같은 책: 0.6
다른 학교 같은 저자: 0.1
다른 학교 흡연 여부 동일: 0.2

리뷰 길이 체크: 0.5
비슷한 나이대 체크: 0.4
