### PR TITLE
feat: 00시에 필터링된 사용자를 제거하도록 변경

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/repository/MemberMatchingRepository.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/MemberMatchingRepository.java
@@ -26,4 +26,8 @@ public interface MemberMatchingRepository extends JpaRepository<MemberMatching, 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "UPDATE member_matching SET is_invitation_card = :isInvitationCard", nativeQuery = true)
     void resetIsInvitationCard(@Param("isInvitationCard") boolean isInvitationCard);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = "UPDATE member_matching SET current_matched_member_id = NULL, current_matched_member_book_id = NULL", nativeQuery = true)
+    void resetCurrentMatchedInfo();
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingAlgorithmFilter.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingAlgorithmFilter.java
@@ -47,7 +47,6 @@ public class MemberMatchingAlgorithmFilter {
                         book -> book.getBook().getAuthors())
                 );
 
-        log.info("추천 회원의 책 저자 리스트를 가져오는 쿼리 ⬇️⬇️⬇️");
         Map<Long, List<String>> matchingMemberBookAuthorsMap = memberBookMap.values().stream()
                 .collect(Collectors.toMap(
                         MemberBook::getId,

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
@@ -102,6 +102,10 @@ public class MemberMatchingService {
         MemberMatching memberMatching = memberMatchingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new BaseException(MemberMatchingExceptionType.NOT_FOUND_MATCHING));
 
+        if (!memberMatching.hasCurrentMatchedInfo()) {
+            return getRecommendationMember(memberId);
+        }
+
         Long refreshMemberId = memberMatching.getCurrentMatchedMemberId();
         Long refreshMemberBookId = memberMatching.getCurrentMatchedMemberBookId();
 


### PR DESCRIPTION
## 📄 Summary

> `@Scheduled` 를 사용해서 매일 자정에 필터링된 회원 정보를 날리도록 구현했습니다

1. matchedInfo 테이블 전부 삭제
2. current_matched_member_id, current_matched_member_book_id 를 NULL 로 변경 -> 이후 NULL 이면 새로 추천 회원을 뽑기
