### PR TITLE
fix: 알고리즘 가중치 로직 변경(곱연산 적용)

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchedInfo.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/repository/entity/MatchedInfo.java
@@ -32,6 +32,10 @@ public class MatchedInfo {
         this.similarityWeight += similarityWeight;
     }
 
+    public void multiplySimilarityWeight(Double similarityWeight) {
+        this.similarityWeight *= similarityWeight;
+    }
+
     public static MatchedInfo from(Long memberId, Long matchedMemberId, Long matchedMemberBookId, MemberMatching memberMatching) {
         return MatchedInfo.builder()
                 .memberId(memberId)
@@ -39,9 +43,5 @@ public class MatchedInfo {
                 .matchedMemberBookId(matchedMemberBookId)
                 .memberMatching(memberMatching)
                 .build();
-    }
-
-    public void updateMemberMatching(MemberMatching memberMatching) {
-        this.memberMatching = memberMatching;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingAlgorithmFilter.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingAlgorithmFilter.java
@@ -69,36 +69,28 @@ public class MemberMatchingAlgorithmFilter {
     private void applySimilarityWeight(Member member, MatchedInfo matchedInfo, Member matchingMember, List<MemberBook> memberBooks,
                                        MemberBook matchingMemberBook, Map<Long, List<String>> memberBookAuthorsMap, Map<Long, List<String>> matchingMemberBookAuthorsMap) {
 
-        if (isSameSchool(member, matchingMember)) { // 같은 학교
-            if (isSameBook(memberBooks, matchingMemberBook)) { // 같은 책
-                matchedInfo.accumulateSimilarityWeight(SAME_SCHOOL_SAME_BOOK);
-            } else if (isSameAuthor(memberBookAuthorsMap, matchingMemberBookAuthorsMap, matchingMemberBook)) { // 같은 저자
-                matchedInfo.accumulateSimilarityWeight(SAME_SCHOOL_SAME_AUTHOR);
-            } else {
-                matchedInfo.accumulateSimilarityWeight(SAME_SCHOOL);
-            }
-
-            if (isSameSmoking(member, matchingMember)) { // 같은 흡연 여부
-                matchedInfo.accumulateSimilarityWeight(SAME_SCHOOL_SAME_SMOKING);
-            }
-        } else { // 다른 학교
-            if (isSameBook(memberBooks, matchingMemberBook)) { // 같은 책
-                matchedInfo.accumulateSimilarityWeight(SAME_BOOK);
-            } else if (isSameAuthor(memberBookAuthorsMap, matchingMemberBookAuthorsMap, matchingMemberBook)) { // 같은 저자
-                matchedInfo.accumulateSimilarityWeight(SAME_AUTHOR);
-            }
-
-            if (isSameSmoking(member, matchingMember)) { // 같은 흡연 여부
-                matchedInfo.accumulateSimilarityWeight(SAME_SMOKING);
-            }
+        if (isSameSchool(member, matchingMember)) {
+            matchedInfo.accumulateSimilarityWeight(SAME_SCHOOL);
         }
 
-        if (checkReviewLength(matchingMemberBook)) { // 리뷰 길이 체크
-            matchedInfo.accumulateSimilarityWeight(GREAT_REVIEW);
+        if (isSameSmoking(member, matchingMember)) {
+            matchedInfo.accumulateSimilarityWeight(SAME_SMOKING);
         }
 
-        if (checkAgeDifference(member, matchingMember)) { // 나이 차이 체크
+        if (checkAgeDifference(member, matchingMember)) {
             matchedInfo.accumulateSimilarityWeight(PEER);
+        }
+
+        /* 아래부터 곱연산 적용 */
+
+        matchedInfo.multiplySimilarityWeight(getReviewWeight(matchingMemberBook.getReview().length()));
+
+        if (isSameBook(memberBooks, matchingMemberBook)) {
+            matchedInfo.multiplySimilarityWeight(SAME_BOOK);
+        } else if (isSameAuthor(memberBookAuthorsMap, matchingMemberBookAuthorsMap, matchingMemberBook)) {
+            matchedInfo.multiplySimilarityWeight(SAME_AUTHOR);
+        } else {
+            matchedInfo.multiplySimilarityWeight(BOOK_DEFAULT);
         }
     }
 

--- a/src/main/java/com/bookbla/americano/domain/matching/service/dto/MatchingSimilarityWeightConstants.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/dto/MatchingSimilarityWeightConstants.java
@@ -2,17 +2,26 @@ package com.bookbla.americano.domain.matching.service.dto;
 
 public class MatchingSimilarityWeightConstants {
 
-    public static final double SAME_SCHOOL_SAME_BOOK = 1.0;
-    public static final double SAME_SCHOOL_SAME_AUTHOR = 0.4;
+    public static final double REVIEW_100 = 1.0;
+    public static final double MIN_WEIGHT = 0.05;
+    public static final double WEIGHT_STEP = 0.05;
 
-    public static final double GREAT_REVIEW = 0.5; // 60자 이상
-    public static final double GOOD_REVIEW = 0.2; // 30자 이상
-
-    public static final double SAME_SCHOOL_SAME_SMOKING = 0.3;
+    public static final double SAME_SCHOOL = 0.3;
     public static final double SAME_SMOKING = 0.2;
-    public static final double SAME_SCHOOL = 0.2;
-    public static final double SAME_BOOK = 0.6;
-    public static final double SAME_AUTHOR = 0.1;
 
-    public static final double PEER = 0.4;
+    public static final double SAME_BOOK = 2.0;
+    public static final double SAME_AUTHOR = 1.5;
+    public static final double BOOK_DEFAULT = 1.0;
+
+    public static final double PEER = 0.2;
+
+    public static double getReviewWeight(int reviewLength) {
+        if (reviewLength >= 100) {
+            return REVIEW_100;
+        }
+
+        double weight = reviewLength / 5 * WEIGHT_STEP;
+
+        return Math.max(weight, MIN_WEIGHT);
+    }
 }

--- a/src/test/java/com/bookbla/americano/domain/matching/service/dto/MatchingSimilarityWeightConstantsTest.java
+++ b/src/test/java/com/bookbla/americano/domain/matching/service/dto/MatchingSimilarityWeightConstantsTest.java
@@ -1,0 +1,67 @@
+package com.bookbla.americano.domain.matching.service.dto;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.bookbla.americano.domain.matching.service.dto.MatchingSimilarityWeightConstants.getReviewWeight;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class MatchingSimilarityWeightConstantsTest {
+
+    @Test
+    public void 리뷰_글자수에_따라_정확한_가중치가_나와야한다() {
+        assertAll(
+                // 리뷰 길이가 100 이상일 경우
+                () -> assertEquals(1.0, getReviewWeight(100), 0.0001),
+                () -> assertEquals(1.0, getReviewWeight(150), 0.0001),
+
+                // 95 ~ 99
+                () -> assertEquals(0.95, getReviewWeight(95), 0.0001),
+
+                // 90 ~ 94
+                () -> assertEquals(0.9, getReviewWeight(94), 0.0001),
+
+                // 85 ~ 89
+                () -> assertEquals(0.85, getReviewWeight(88), 0.0001),
+
+                // 75 ~ 79
+                () -> assertEquals(0.75, getReviewWeight(77), 0.0001),
+
+                // 55 ~ 59
+                () -> assertEquals(0.55, getReviewWeight(56), 0.0001),
+
+                // 25 ~ 29
+                () -> assertEquals(0.25, getReviewWeight(25), 0.0001),
+
+                // 10 ~ 14
+                () -> assertEquals(0.1, getReviewWeight(12), 0.0001),
+
+                // 0 ~ 4
+                () -> assertEquals(0.05, getReviewWeight(0), 0.0001),
+                () -> assertEquals(0.05, getReviewWeight(4), 0.0001)
+        );
+    }
+
+    @Test
+    public void 리뷰_길이가_5_이하일_경우_최소_가중치_반환() {
+        assertAll(
+                () -> assertEquals(0.05, getReviewWeight(1), 0.0001),
+                () -> assertEquals(0.05, getReviewWeight(4), 0.0001),
+                () -> assertEquals(0.05, getReviewWeight(0), 0.0001)
+        );
+    }
+
+    @Test
+    public void 리뷰_길이가_100_이상일_경우_최대_가중치_반환() {
+        assertAll(
+                () -> assertEquals(1.0, getReviewWeight(100), 0.0001),
+                () -> assertEquals(1.0, getReviewWeight(150), 0.0001)
+        );
+    }
+}

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import javax.transaction.Transactional;
-
 import static com.bookbla.americano.domain.postcard.enums.PostcardStatus.REFUSED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;


### PR DESCRIPTION
## 📄 Summary

### 가중치

합연산

- 같은 학교 0.3
- 같은 흡연 0.2
- 동일 나이대 0.2

상수 합연산 후 곱연산 적용

- 리뷰 길이 (20~) 차등 부여 0.1~1.0
    - 100글자 이상 - 1.0
    - 90 이상 - 0.9
    - 80 이상 - 0.8
    - 70 이상 - 0.7
    - …
    - 20글자 - 0.2
    - 그 밑 - 0.05
- 같은 책 2.0
- 같은 저자 1.5
- else 1.0