### PR TITLE
feat: 받은 엽서 중 이미 확인한 엽서는 조회하지 않게 변경

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/repository/custom/impl/PostcardRepositoryCustomImpl.java
@@ -72,9 +72,7 @@ public class PostcardRepositoryCustomImpl implements PostcardRepositoryCustom {
                 .from(member)
                 .innerJoin(postcard).on(member.eq(postcard.sendMember))
                 .where(postcard.receiveMember.id.eq(memberId)
-                        .and(postcard.postcardStatus.eq(PostcardStatus.PENDING)
-                                .or(postcard.postcardStatus.eq(PostcardStatus.READ))
-                                .or(postcard.postcardStatus.eq(PostcardStatus.ACCEPT))))
+                        .and(postcard.postcardStatus.eq(PostcardStatus.PENDING)))
                 .orderBy(postcard.createdAt.desc())
                 .fetch();
     }


### PR DESCRIPTION
## 📄 Summary

> 기획에서 이미 읽은 엽서는 우편함에서 보여주지 않는 것으로 처리해서 Status - READ, ACCEPT상태의 엽서는 조건에서 제외했습니다!
## 🙋🏻 More

>