### PR TITLE
fix: 채팅방 생성 로직 변경에 따라 api req, res 변경

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardReadResponse.java
@@ -1,14 +1,29 @@
 package com.bookbla.americano.domain.postcard.controller.dto.response;
 
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class PostcardReadResponse {
-    private final String channelUrl;
 
-    public static PostcardReadResponse from(String channelUrl) {
-        return new PostcardReadResponse(channelUrl);
+    private Long sendMemberId;
+
+    private Long receiveMemberId;
+
+    private Long receiveMemberBookId;
+
+    private  String memberReply;
+
+    public static PostcardReadResponse of(Postcard postcard) {
+        return new PostcardReadResponse(
+                postcard.getSendMember().getId(),
+                postcard.getReceiveMember().getId(),
+                postcard.getReceiveMemberBook().getId(),
+                postcard.getMessage());
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -95,7 +95,6 @@ public class PostcardService {
                 .message(request.getMemberReply())
                 .postcardType(postCardType)
                 .imageUrl(postCardType.getImageUrl())
-                .channelUrl(request.getChannelUrl())
                 .build();
         postcardRepository.save(postcard);
 
@@ -169,7 +168,7 @@ public class PostcardService {
         memberBookmark.readPostcard();
         updatePostcardStatus(memberId, postcardId, PostcardStatus.READ);
 
-        return PostcardReadResponse.from(postcard.getChannelUrl());
+        return PostcardReadResponse.of(postcard);
     }
 
     public PostcardStatus getPostcardStatus(Long postcardId) {

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
@@ -16,6 +16,9 @@ public class SendPostcardRequest {
     @NotNull(message = "postcardTypeId가 입력되지 않았습니다.")
     private Long postcardTypeId;
 
+    @NotNull(message = "엽서를 보낼 사용자의 식별자가 입력되지 않았습니다")
+    private Long sendMemberId;
+
     @NotNull(message = "엽서를 보낼 상대방의 식별자가 입력되지 않았습니다")
     private Long receiveMemberId;
 
@@ -25,7 +28,4 @@ public class SendPostcardRequest {
     @NotNull(message = "memberReply가 입력되지 않았습니다.")
     @Size(max = 150)
     private String memberReply;
-
-    @NotNull(message = "channelUrl이 입력되지않았습니다.")
-    private String channelUrl;
 }

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/SendPostcardResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/response/SendPostcardResponse.java
@@ -9,5 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @RequiredArgsConstructor
 public class SendPostcardResponse {
+
     private final Boolean isSendSuccess;
 }

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -12,11 +12,7 @@ import com.bookbla.americano.domain.member.repository.MemberBlockRepository;
 import com.bookbla.americano.domain.member.repository.MemberBookRepository;
 import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
 import com.bookbla.americano.domain.member.repository.MemberRepository;
-import com.bookbla.americano.domain.member.repository.entity.Member;
-import com.bookbla.americano.domain.member.repository.entity.MemberBlock;
-import com.bookbla.americano.domain.member.repository.entity.MemberBook;
-import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
-import com.bookbla.americano.domain.member.repository.entity.MemberProfile;
+import com.bookbla.americano.domain.member.repository.entity.*;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardSendValidateResponse;
 import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
@@ -27,12 +23,7 @@ import com.bookbla.americano.domain.postcard.repository.entity.PostcardType;
 import com.bookbla.americano.domain.postcard.service.dto.request.SendPostcardRequest;
 import com.bookbla.americano.domain.postcard.service.dto.response.SendPostcardResponse;
 import com.bookbla.americano.domain.quiz.repository.QuizQuestionRepository;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,8 +89,12 @@ class PostcardServiceTest {
                 .member(sendMember)
                 .bookmarkCount(100).build();
         bookmarkRepository.save(memberBookmark);
-        String channelUrl = "aaabbbccc";
-        SendPostcardRequest request = new SendPostcardRequest(postcardType.getId(), receiveMember.getId(), receiveMemberBook.getId(), "memberReply", channelUrl);
+        SendPostcardRequest request = new SendPostcardRequest(
+                postcardType.getId(),
+                sendMember.getId(),
+                receiveMember.getId(),
+                receiveMemberBook.getId(),
+                "memberReply");
 
         //when & then
         assertThatThrownBy(() -> sut.send(sendMember.getId(), request))
@@ -125,8 +120,12 @@ class PostcardServiceTest {
                 .currentMatchedMemberBookId(receiveMemberBook.getId())
                 .isInvitationCard(false)
                 .build());
-        String channelUrl = "aaabbbccc";
-        SendPostcardRequest request = new SendPostcardRequest(postcardType.getId(), receiveMember.getId(), receiveMemberBook.getId(), "memberReply", channelUrl);
+        SendPostcardRequest request = new SendPostcardRequest(
+                postcardType.getId(),
+                sendMember.getId(),
+                receiveMember.getId(),
+                receiveMemberBook.getId(),
+                "memberReply");
 
         //when
         SendPostcardResponse response = sut.send(sendMember.getId(), request);
@@ -150,8 +149,12 @@ class PostcardServiceTest {
                 .member(sendMember)
                 .bookmarkCount(10).build();
         bookmarkRepository.save(memberBookmark);
-        String channelUrl = "aaabbbccc";
-        SendPostcardRequest request = new SendPostcardRequest(postcardType.getId(), receiveMember.getId(), receiveMemberBook.getId(), "memberReply", channelUrl);
+        SendPostcardRequest request = new SendPostcardRequest(
+                postcardType.getId(),
+                sendMember.getId(),
+                receiveMember.getId(),
+                receiveMemberBook.getId(),
+                "memberReply");
 
         // when & then
         assertThatThrownBy(() -> sut.send(sendMember.getId(), request))


### PR DESCRIPTION
### 📄 Summary

## api 변경사항
`POST postcard/send`
```
req
{
    "postcardTypeId": 0, 
    “sendMemberId”: 0, - 추가
    “sendMemberName”: “string”, - 추가
    "receiveMemberId": 0,
    "receiveMemberBookId": 0,
    "memberReply": "string",
    "channelUrl": "string" - 삭제
}
```

`POST postcard/read/{postcardId}`
```
res
{
    "channelUrl": "string" 삭제
     “sendMemberId”: 0, - 추가
    “sendMemberName”: “string”, - 추가
    "receiveMemberId": 0, - 추가
    "receiveMemberBookId": 0, - 추가
    "memberReply": "string", - 추가
}
```