### PR TITLE
fix: 엽서 보내기 로직에서 sendMemberId Param 제거

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardReadResponse.java
@@ -13,6 +13,8 @@ public class PostcardReadResponse {
 
     private Long sendMemberId;
 
+    private String sendMemberName;
+
     private Long receiveMemberId;
 
     private Long receiveMemberBookId;
@@ -22,6 +24,7 @@ public class PostcardReadResponse {
     public static PostcardReadResponse of(Postcard postcard) {
         return new PostcardReadResponse(
                 postcard.getSendMember().getId(),
+                postcard.getSendMember().getMemberProfile().getName(),
                 postcard.getReceiveMember().getId(),
                 postcard.getReceiveMemberBook().getId(),
                 postcard.getMessage());

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/dto/request/SendPostcardRequest.java
@@ -16,9 +16,6 @@ public class SendPostcardRequest {
     @NotNull(message = "postcardTypeId가 입력되지 않았습니다.")
     private Long postcardTypeId;
 
-    @NotNull(message = "엽서를 보낼 사용자의 식별자가 입력되지 않았습니다")
-    private Long sendMemberId;
-
     @NotNull(message = "엽서를 보낼 상대방의 식별자가 입력되지 않았습니다")
     private Long receiveMemberId;
 

--- a/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/postcard/service/PostcardServiceTest.java
@@ -91,7 +91,6 @@ class PostcardServiceTest {
         bookmarkRepository.save(memberBookmark);
         SendPostcardRequest request = new SendPostcardRequest(
                 postcardType.getId(),
-                sendMember.getId(),
                 receiveMember.getId(),
                 receiveMemberBook.getId(),
                 "memberReply");
@@ -122,7 +121,6 @@ class PostcardServiceTest {
                 .build());
         SendPostcardRequest request = new SendPostcardRequest(
                 postcardType.getId(),
-                sendMember.getId(),
                 receiveMember.getId(),
                 receiveMemberBook.getId(),
                 "memberReply");
@@ -151,7 +149,6 @@ class PostcardServiceTest {
         bookmarkRepository.save(memberBookmark);
         SendPostcardRequest request = new SendPostcardRequest(
                 postcardType.getId(),
-                sendMember.getId(),
                 receiveMember.getId(),
                 receiveMemberBook.getId(),
                 "memberReply");


### PR DESCRIPTION
## 📄 Summary

>
## 🙋🏻 More

>