### PR TITLE
fix: 자정에 current 정보가 날라가는 버그 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/controller/dto/response/MemberIntroResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/controller/dto/response/MemberIntroResponse.java
@@ -51,6 +51,7 @@ public class MemberIntroResponse {
     }
 
     public static MemberIntroResponse empty() {
-        return MemberIntroResponse.builder().build();
+        return MemberIntroResponse.builder()
+                .isInvitationCard(true).build();
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
@@ -49,6 +49,10 @@ public class MemberMatchingService {
         MemberMatching memberMatching = memberMatchingRepository.findByMemberId(memberId)
                 .orElseGet(() -> memberMatchingRepository.save(MemberMatching.of(member)));
 
+        if (memberMatching.getIsInvitationCard()) {
+            return MemberIntroResponse.empty();
+        }
+
         if (memberMatching.hasCurrentMatchedInfo()) {
             MatchedInfo matchedInfo = getMatchedInfo(memberId, memberMatching);
 


### PR DESCRIPTION
## 📄 Summary

> 간단하게 방어 로직 구현했습니다

자정에 홈 화면 접속 시 currentMatchedInfo가 저장되는데 이러면 새로운 사람 만나기(refresh) 시에 current 정보가 날라가도록 작성되어 있었는데  
이를 자정에 홈 화면 접속 시 isInvitationCard를 보내줘서 홈 화면에 초대 카드를 띄워주도록 변경했습니다