### PR TITLE
fix: 초대된 회원 보상에서 남성/여성 회원 구분 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/controller/MemberModalController.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/MemberModalController.java
@@ -3,6 +3,7 @@ package com.bookbla.americano.domain.member.controller;
 import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
 import com.bookbla.americano.domain.member.controller.dto.request.MemberOnboardingStatusRequest;
+import com.bookbla.americano.domain.member.controller.dto.request.UpdateInvitationRewardRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberInvitationRewardResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberOnboardingStatusResponse;
 import com.bookbla.americano.domain.member.service.MemberModalService;
@@ -55,8 +56,9 @@ public class MemberModalController {
                     + "memberOnboardingStatus : [NONE, BOOKMARK, COMPLETED]")
     @PostMapping("/invitation-reward")
     public ResponseEntity<MemberInvitationRewardResponse> updateInvitationRewardStatus(
-            @Parameter(hidden = true) @User LoginUser loginUser
+            @Parameter(hidden = true) @User LoginUser loginUser,
+            @RequestBody @Valid UpdateInvitationRewardRequest request
     ) {
-        return ResponseEntity.ok(invitationService.updateInvitationRewardStatus(loginUser.getMemberId()));
+        return ResponseEntity.ok(invitationService.updateInvitationRewardStatus(loginUser.getMemberId(), request));
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/UpdateInvitationRewardRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/request/UpdateInvitationRewardRequest.java
@@ -1,0 +1,17 @@
+package com.bookbla.americano.domain.member.controller.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@AllArgsConstructor
+@Getter
+public class UpdateInvitationRewardRequest {
+
+    @NotNull
+    private String invitedRewardStatus;
+
+}

--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberInvitationRewardResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberInvitationRewardResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class MemberInvitationRewardResponse {
 
     private Boolean invitingRewardStatus;
-    private String invitedRewardStatus; // 초대코드 입력 안함 -> NONE, 다른 회원 초대코드 입력 -> MEMBER, 축제 코드 입력 -> FESTIVAL
+    private String invitedRewardStatus; // 초대코드 입력 안함 -> NONE, 다른 회원 초대코드 입력 -> FEMALE, MALE, 축제 코드 입력 -> FESTIVAL
     private String invitedMembersGender;
 
     public static MemberInvitationRewardResponse fromInvitingRewardNotGiven(String invitedRewardStatus) {

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
@@ -60,7 +60,7 @@ public class MemberModal {
         this.libraryOnboarding = Boolean.TRUE;
     }
 
-    public boolean isInvitedRewardNotGiven() {
+    public boolean isFemaleInvitedRewardNotGiven() {
         return femaleInvitedRewardStatus == InvitationStatus.BOOKMARK;
     }
 
@@ -105,5 +105,9 @@ public class MemberModal {
 
     public void updateFestivalInvitationToExists() {
         this.hasFestivalInvitationReward = Boolean.TRUE;
+    }
+
+    public boolean isMaleInvitedRewardNotGiven() {
+        return maleInvitedRewardStatus == InvitationStatus.BOOKMARK;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
@@ -110,4 +110,23 @@ public class MemberModal {
     public boolean isMaleInvitedRewardNotGiven() {
         return maleInvitedRewardStatus == InvitationStatus.BOOKMARK;
     }
+
+    public String getMemberInvitedRewardStatus() {
+        if (isFemaleInvitedRewardNotGiven()) {
+            updateFemaleInvitedRewardStatusToComplete();
+            return "FEMALE";
+        }
+
+        if (isMaleInvitedRewardNotGiven()) {
+            updateMaleInvitedRewardStatusToComplete();
+            return "MALE";
+        }
+
+        if (hasFestivalInvitationReward()) {
+            completeFestivalInvitationModal();
+            return "FESTIVAL";
+        }
+
+        return "NONE";
+    }
 }

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
@@ -46,7 +46,11 @@ public class MemberModal {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
-    private InvitationStatus invitedRewardStatus = InvitationStatus.NONE;
+    private InvitationStatus femaleInvitedRewardStatus = InvitationStatus.NONE;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private InvitationStatus maleInvitedRewardStatus = InvitationStatus.NONE;
 
     public void updateMemberHomeOnboarding() {
         this.homeOnboarding = Boolean.TRUE;
@@ -57,19 +61,27 @@ public class MemberModal {
     }
 
     public boolean isInvitedRewardNotGiven() {
-        return invitedRewardStatus == InvitationStatus.BOOKMARK;
+        return femaleInvitedRewardStatus == InvitationStatus.BOOKMARK;
     }
 
     public boolean isInvitingRewardNotGiven() {
         return invitingRewardStatus.entrySet().stream().anyMatch(entry -> entry.getValue().equals(Boolean.FALSE));
     }
 
-    public void updateMemberInvitedRewardStatusToBookmark() {
-        this.invitedRewardStatus = InvitationStatus.BOOKMARK;
+    public void updateFemaleInvitedRewardStatusToBookmark() {
+        this.femaleInvitedRewardStatus = InvitationStatus.BOOKMARK;
     }
 
-    public void updateMemberInvitedRewardStatusToComplete() {
-        this.invitedRewardStatus = InvitationStatus.COMPLETED;
+    public void updateFemaleInvitedRewardStatusToComplete() {
+        this.femaleInvitedRewardStatus = InvitationStatus.COMPLETED;
+    }
+
+    public void updateMaleInvitedRewardStatusToBookmark() {
+        this.maleInvitedRewardStatus = InvitationStatus.BOOKMARK;
+    }
+
+    public void updateMaleInvitedRewardStatusToComplete() {
+        this.maleInvitedRewardStatus = InvitationStatus.COMPLETED;
     }
 
     public Long getInvitedMemberId() {

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -70,7 +70,12 @@ public class InvitationService {
                 .orElseThrow(() -> new BaseException(MemberExceptionType.INVITATION_CODE_NOT_FOUND));
         Member invitedMember = memberRepository.getByIdOrThrow(invitedMemberId);
 
-        invitedMember.getMemberModal().updateMemberInvitedRewardStatusToBookmark();
+        if (invitedMember.isWoman()) {
+            invitedMember.getMemberModal().updateFemaleInvitedRewardStatusToBookmark();
+        } else {
+            invitedMember.getMemberModal().updateMaleInvitedRewardStatusToBookmark();
+        }
+
         invitingMember.getMemberModal().getInvitingRewardStatus().put(invitedMemberId, Boolean.FALSE);
 
         Invitation invitation = invitationRepository.findByInvitedMemberId(invitedMemberId)
@@ -161,7 +166,7 @@ public class InvitationService {
         String invitedRewardStatus = "NONE";
 
         if (modal.isInvitedRewardNotGiven()) {
-            modal.updateMemberInvitedRewardStatusToComplete();
+            modal.updateFemaleInvitedRewardStatusToComplete();
             invitedRewardStatus = "MEMBER";
         }
 
@@ -184,7 +189,7 @@ public class InvitationService {
     public MemberInvitationRewardResponse updateInvitationRewardStatus(Long memberId) {
         Member member = memberRepository.getByIdOrThrow(memberId);
 
-        member.getMemberModal().updateMemberInvitedRewardStatusToComplete();
+        member.getMemberModal().updateFemaleInvitedRewardStatusToComplete();
 
         return getInvitationRewardStatus(memberId);
     }

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -165,9 +165,14 @@ public class InvitationService {
 
         String invitedRewardStatus = "NONE";
 
-        if (modal.isInvitedRewardNotGiven()) {
+        if (modal.isFemaleInvitedRewardNotGiven()) {
             modal.updateFemaleInvitedRewardStatusToComplete();
-            invitedRewardStatus = "MEMBER";
+            invitedRewardStatus = "FEMALE";
+        }
+
+        if (modal.isMaleInvitedRewardNotGiven()) {
+            modal.updateMaleInvitedRewardStatusToComplete();
+            invitedRewardStatus = "MALE";
         }
 
         if (modal.hasFestivalInvitationReward()) {

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -163,22 +163,7 @@ public class InvitationService {
         Member member = memberRepository.getByIdOrThrow(memberId);
         MemberModal modal = member.getMemberModal();
 
-        String invitedRewardStatus = "NONE";
-
-        if (modal.isFemaleInvitedRewardNotGiven()) {
-            modal.updateFemaleInvitedRewardStatusToComplete();
-            invitedRewardStatus = "FEMALE";
-        }
-
-        if (modal.isMaleInvitedRewardNotGiven()) {
-            modal.updateMaleInvitedRewardStatusToComplete();
-            invitedRewardStatus = "MALE";
-        }
-
-        if (modal.hasFestivalInvitationReward()) {
-            modal.completeFestivalInvitationModal();
-            invitedRewardStatus = "FESTIVAL";
-        }
+        String invitedRewardStatus = modal.getMemberInvitedRewardStatus();
 
         if (modal.isInvitingRewardNotGiven()) {
             Long invitedMemberId = modal.getInvitedMemberId();

--- a/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/InvitationService.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.school.service;
 
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.admin.event.AdminNotificationEventListener;
+import com.bookbla.americano.domain.member.controller.dto.request.UpdateInvitationRewardRequest;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberInvitationResponse;
 import com.bookbla.americano.domain.member.controller.dto.response.MemberInvitationRewardResponse;
 import com.bookbla.americano.domain.member.exception.MemberBookmarkExceptionType;
@@ -176,10 +177,15 @@ public class InvitationService {
         return MemberInvitationRewardResponse.fromInvitingRewardNotGiven(invitedRewardStatus);
     }
 
-    public MemberInvitationRewardResponse updateInvitationRewardStatus(Long memberId) {
+    public MemberInvitationRewardResponse updateInvitationRewardStatus(Long memberId, UpdateInvitationRewardRequest request) {
         Member member = memberRepository.getByIdOrThrow(memberId);
 
-        member.getMemberModal().updateFemaleInvitedRewardStatusToComplete();
+        if (request.getInvitedRewardStatus().equals("MALE")) {
+            member.getMemberModal().updateMaleInvitedRewardStatusToComplete();
+        }
+        if (request.getInvitedRewardStatus().equals("FEMALE")) {
+            member.getMemberModal().updateFemaleInvitedRewardStatusToComplete();
+        }
 
         return getInvitationRewardStatus(memberId);
     }

--- a/src/test/java/com/bookbla/americano/domain/school/service/InvitationServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/school/service/InvitationServiceTest.java
@@ -225,12 +225,46 @@ class InvitationServiceTest {
         }
 
         @Test
-        void 초대되었다면_초대보상을_받을_수_있다() {
+        void 남성_회원이_초대됐다면_초대된_회원_보상_남성으로_반환한다() {
             // given
             Member man1 = memberRepository.save(스타일_등록_완료_남성_고도리);
             Member man2 = memberRepository.save(프로필_등록_완료_남성_리준희);
-            MemberBookmark man1MemberBookmark = memberBookmarkRepository.save(MemberBookmark.builder().member(man1).build());
-            MemberBookmark man2MemberBookmark = memberBookmarkRepository.save(MemberBookmark.builder().member(man2).build());
+            memberBookmarkRepository.save(MemberBookmark.builder().member(man1).build());
+            memberBookmarkRepository.save(MemberBookmark.builder().member(man2).build());
+
+            sut.entryInvitationCode(man2.getId(), new InvitationCodeEntryRequest("고도리초대코드"));
+
+            // when
+            var response = sut.getInvitationRewardStatus(man2.getId());
+
+            // then
+            assertThat(response.getInvitedRewardStatus()).isEqualTo("MALE");
+        }
+
+        @Test
+        void 여성_회원이_초대됐다면_초대된_회원_보상_여성으로_반환한다() {
+            // given
+            Member invitingMember = memberRepository.save(스타일_등록_완료_남성_고도리);
+            Member invitedFemaleMember = memberRepository.save(프로필_등록_완료_여성_김밤비);
+            memberBookmarkRepository.save(MemberBookmark.builder().member(invitingMember).build());
+            memberBookmarkRepository.save(MemberBookmark.builder().member(invitedFemaleMember).build());
+
+            sut.entryInvitationCode(invitedFemaleMember.getId(), new InvitationCodeEntryRequest("고도리초대코드"));
+
+            // when
+            var response = sut.getInvitationRewardStatus(invitedFemaleMember.getId());
+
+            // then
+            assertThat(response.getInvitedRewardStatus()).isEqualTo("FEMALE");
+        }
+
+        @Test
+        void 여성_회원이_초대됐다면_여성_초대_보상을_받을_수_있다() {
+            // given
+            Member invitingManMember = memberRepository.save(스타일_등록_완료_남성_고도리);
+            Member man2 = memberRepository.save(프로필_등록_완료_남성_리준희);
+            memberBookmarkRepository.save(MemberBookmark.builder().member(invitingManMember).build());
+            memberBookmarkRepository.save(MemberBookmark.builder().member(man2).build());
 
             // when
             sut.entryInvitationCode(man2.getId(), new InvitationCodeEntryRequest("고도리초대코드"));
@@ -238,7 +272,7 @@ class InvitationServiceTest {
 
             // then
             assertThat(response.getInvitingRewardStatus()).isFalse();
-            assertThat(response.getInvitedRewardStatus()).isEqualTo("MEMBER");
+            assertThat(response.getInvitedRewardStatus()).isEqualTo("MALE");
             assertThat(response.getInvitedMembersGender()).isNull();
         }
 


### PR DESCRIPTION
## 📄 Summary

> 초대받은 회원 보상 구분을 위해 invitingRewardStatus의 반환값 member를 feamle, male로 나누어 반환하게 하였습니다

## 기존
```[GET] /member-modal/invitation-reward```

ResponseBody
```
private Boolean invitingRewardStatus;
private String invitedRewardStatus; // 다른 회원 초대코드 입력 -> MEMBER
private String invitedMembersGender;
```


## 수정 후

```[GET] /member-modal/invitation-reward```
ResponseBody
```java
private Boolean invitingRewardStatus;
private String invitedRewardStatus; // 다른 회원 초대코드 입력 -> FEMALE, MALE
private String invitedMembersGender;
```

```[POST] /member-modal/invitation-reward```
GET 요청에서 받은 invitedRewardStatus를 그대로 body로 보내서
해당하는 정보를 변경하도록 변경하였습니다

RequestBody
```
{
    "invitedRewardStatus" : String
}
```
## 🙋🏻 More

>

### MemberModal 필드 변경

invitedRewardStatus 제거
femaleInvitedRewardStatus 추가
maleInvitedRewardStatus 추가
