### PR TITLE
fix: 엽서퀴즈 틀리고 홈왔을때 그 매칭정보가 다시 뜨는 문제 해결

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
@@ -49,6 +49,9 @@ public class MemberMatchingService {
                 .orElseGet(() -> memberMatchingRepository.save(MemberMatching.of(member)));
 
         if (memberMatching.hasCurrentMatchedInfo()) {
+            if(memberMatching.getIsInvitationCard()){
+                return MemberIntroResponse.showInvitationCard();
+            }
             MatchedInfo matchedInfo = getMatchedInfo(memberId, memberMatching);
 
             return buildMemberIntroResponseWithMatchedInfo(matchedInfo, memberMatching);


### PR DESCRIPTION
## 📄 Summary

>
## 🙋🏻 More

>