### PR TITLE
fix: 엽서(채팅) 수락/거절시 postcard 상태 변경 및 책갈피 개수 업데이트

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/notification/event/PushAlarmEventHandler.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/event/PushAlarmEventHandler.java
@@ -70,10 +70,10 @@ public class PushAlarmEventHandler {
             throw new BaseException(PushAlarmExceptionType.INVALID_MEMBER_STATUS);
         }
 
-        Member pushAlarmSendMember = postcardAlarmEvent.getPushAlarmSendMember();
+        String sendMemberName = postcardAlarmEvent.getPushAlarmSendMember().getMemberProfile().getName();
 
         String title = POSTCARD_ACCEPT.getTitle();
-        String body = String.format(POSTCARD_ACCEPT.getBody(), pushAlarmSendMember);
+        String body = String.format(POSTCARD_ACCEPT.getBody(), sendMemberName);
 
         notificationClient.send(targetMember.getPushToken(), title, body);
 

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/PostcardController.java
@@ -49,6 +49,7 @@ public class PostcardController {
         return ResponseEntity.ok(postcardReadResponse);
     }
 
+    @Deprecated
     @Operation(summary = "Postcard 상태 업데이트", description = "Body의 postcardId를 가진 엽서의 상태 업데이트. Body의 status 값으로 해당 엽서의 상태(PostcardStatus)를 변경함.")
     @PostMapping("/status")
     public void updatePostcardStatus(@Parameter(hidden = true) @User LoginUser loginUser,

--- a/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardReadResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/controller/dto/response/PostcardReadResponse.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PostcardReadResponse {
 
+    private Long postcardId;
+
     private Long sendMemberId;
 
     private String sendMemberName;
@@ -23,6 +25,7 @@ public class PostcardReadResponse {
 
     public static PostcardReadResponse of(Postcard postcard) {
         return new PostcardReadResponse(
+                postcard.getId(),
                 postcard.getSendMember().getId(),
                 postcard.getSendMember().getMemberProfile().getName(),
                 postcard.getReceiveMember().getId(),

--- a/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
+++ b/src/main/java/com/bookbla/americano/domain/postcard/service/PostcardService.java
@@ -174,7 +174,7 @@ public class PostcardService {
         sendbirdService.freezeSendbirdGroupChannel(channelUrl);
 
         memberBookmark.readPostcard();
-        updatePostcardStatus(memberId, postcardId, PostcardStatus.READ);
+        postcardRepository.updatePostcardStatus(PostcardStatus.READ, postcardId);
 
         return PostcardReadResponse.of(postcard);
     }
@@ -186,6 +186,7 @@ public class PostcardService {
         return postcard.getPostcardStatus();
     }
 
+    @Deprecated
     public void updatePostcardStatus(Long memberId, Long postcardId,
                                      PostcardStatus postcardStatus) {
         Postcard postcard = postcardRepository.findByIdWithMembers(postcardId)

--- a/src/main/java/com/bookbla/americano/domain/sendbird/controller/SendbirdController.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/controller/SendbirdController.java
@@ -40,7 +40,8 @@ public class SendbirdController {
     @Operation(summary = "채팅 수락")
     @PostMapping("/entry/accept")
     public ResponseEntity<Void> accept(@RequestBody @Valid EntryRequest entryRequest){
-        chatService.updatePostcardStatusByChat(entryRequest, PostcardStatus.ACCEPT);
+        Long postcardId = sendbirdService.getSendbirdMetadata(entryRequest.getChannelUrl());
+        chatService.updatePostcardStatusByChat(entryRequest, PostcardStatus.ACCEPT, postcardId);
         sendbirdService.unFreezeSendbirdGroupChannel(entryRequest.getChannelUrl());
         return ResponseEntity.ok().build();
     }
@@ -48,7 +49,8 @@ public class SendbirdController {
     @Operation(summary = "채팅 거절")
     @PostMapping("/entry/reject")
     public ResponseEntity<Void> reject(@RequestBody @Valid EntryRequest entryRequest){
-        chatService.updatePostcardStatusByChat(entryRequest, PostcardStatus.REFUSED);
+        Long postcardId = sendbirdService.getSendbirdMetadata(entryRequest.getChannelUrl());
+        chatService.updatePostcardStatusByChat(entryRequest, PostcardStatus.REFUSED, postcardId);
 //        추후 채팅방을 삭제해야 한다면 주석 해제
 //        sendbirdService.deleteSendbirdGroupChannel(entryRequest.getChannelUrl());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/bookbla/americano/domain/sendbird/controller/SendbirdController.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/controller/SendbirdController.java
@@ -2,6 +2,7 @@ package com.bookbla.americano.domain.sendbird.controller;
 
 import com.bookbla.americano.base.resolver.LoginUser;
 import com.bookbla.americano.base.resolver.User;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
 import com.bookbla.americano.domain.sendbird.controller.dto.request.EntryRequest;
 import com.bookbla.americano.domain.sendbird.controller.dto.response.SendbirdResponse;
 import com.bookbla.americano.domain.sendbird.service.ChatService;
@@ -39,7 +40,7 @@ public class SendbirdController {
     @Operation(summary = "채팅 수락")
     @PostMapping("/entry/accept")
     public ResponseEntity<Void> accept(@RequestBody @Valid EntryRequest entryRequest){
-        chatService.chatAccept(entryRequest.getTargetMemberId());
+        chatService.updatePostcardStatusByChat(entryRequest, PostcardStatus.ACCEPT);
         sendbirdService.unFreezeSendbirdGroupChannel(entryRequest.getChannelUrl());
         return ResponseEntity.ok().build();
     }
@@ -47,7 +48,7 @@ public class SendbirdController {
     @Operation(summary = "채팅 거절")
     @PostMapping("/entry/reject")
     public ResponseEntity<Void> reject(@RequestBody @Valid EntryRequest entryRequest){
-        chatService.chatReject(entryRequest.getTargetMemberId());
+        chatService.updatePostcardStatusByChat(entryRequest, PostcardStatus.REFUSED);
 //        추후 채팅방을 삭제해야 한다면 주석 해제
 //        sendbirdService.deleteSendbirdGroupChannel(entryRequest.getChannelUrl());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/bookbla/americano/domain/sendbird/controller/dto/request/EntryRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/controller/dto/request/EntryRequest.java
@@ -15,8 +15,5 @@ public class EntryRequest {
     @NotNull(message = "채팅 수락/거절시 책갈피 처리할 회원이 입력 되지 않았습니다")
     private Long targetMemberId;
 
-    @NotNull(message = "postcardId를 입력하지 않았습니다.")
-    private Long postcardId;
-
     private String channelUrl;
 }

--- a/src/main/java/com/bookbla/americano/domain/sendbird/controller/dto/request/EntryRequest.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/controller/dto/request/EntryRequest.java
@@ -15,5 +15,8 @@ public class EntryRequest {
     @NotNull(message = "채팅 수락/거절시 책갈피 처리할 회원이 입력 되지 않았습니다")
     private Long targetMemberId;
 
+    @NotNull(message = "postcardId를 입력하지 않았습니다.")
+    private Long postcardId;
+
     private String channelUrl;
 }

--- a/src/main/java/com/bookbla/americano/domain/sendbird/service/ChatService.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/service/ChatService.java
@@ -3,7 +3,15 @@ package com.bookbla.americano.domain.sendbird.service;
 import com.bookbla.americano.base.exception.BaseException;
 import com.bookbla.americano.domain.member.exception.MemberExceptionType;
 import com.bookbla.americano.domain.member.repository.MemberBookmarkRepository;
+import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.member.repository.entity.MemberBookmark;
+import com.bookbla.americano.domain.notification.event.PostcardAlarmEvent;
+import com.bookbla.americano.domain.notification.event.PushAlarmEventHandler;
+import com.bookbla.americano.domain.postcard.enums.PostcardStatus;
+import com.bookbla.americano.domain.postcard.exception.PostcardExceptionType;
+import com.bookbla.americano.domain.postcard.repository.PostcardRepository;
+import com.bookbla.americano.domain.postcard.repository.entity.Postcard;
+import com.bookbla.americano.domain.sendbird.controller.dto.request.EntryRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,15 +23,35 @@ import javax.transaction.Transactional;
 public class ChatService {
 
     private final MemberBookmarkRepository memberBookmarkRepository;
+    private final PostcardRepository postcardRepository;
+    private final PushAlarmEventHandler postcardPushAlarmEventListener;
 
-    public void chatAccept(Long targetMemberId) {
+    public void updatePostcardStatusByChat(EntryRequest entryRequest, PostcardStatus postcardStatus) {
+        Postcard postcard = postcardRepository.findByIdWithMembers(entryRequest.getPostcardId())
+                .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
+
+        postcardRepository.updatePostcardStatus(postcardStatus, postcard.getId());
+
+        Member sendMember = postcard.getSendMember();
+        Member receiveMember = postcard.getReceiveMember();
+
+        if (postcardStatus.isAccept()) {
+            updateBookmarkOnChatAccept(entryRequest.getTargetMemberId());
+            postcardPushAlarmEventListener.acceptPostcard(new PostcardAlarmEvent(sendMember, receiveMember));
+        } else if (postcardStatus.isRefused()) {
+            updateBookmarkOnChatReject(entryRequest.getTargetMemberId());
+            postcard.updatePostcardStatusRefusedAt();
+        }
+    }
+
+    public void updateBookmarkOnChatAccept(Long targetMemberId) {
         MemberBookmark targetMemberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(targetMemberId) // 채팅 수락한 사람 책갈피
                 .orElseThrow(() -> new BaseException(MemberExceptionType.EMPTY_MEMBER_BOOKMARK_INFO));
 
         targetMemberBookmark.acceptChat();
     }
 
-    public void chatReject(Long targetMemberId) {
+    public void updateBookmarkOnChatReject(Long targetMemberId) {
         MemberBookmark memberBookmark = memberBookmarkRepository.findMemberBookmarkByMemberId(targetMemberId) // 채팅 보낸 사람 책갈피
                 .orElseThrow(() -> new BaseException(MemberExceptionType.EMPTY_MEMBER_BOOKMARK_INFO));
 

--- a/src/main/java/com/bookbla/americano/domain/sendbird/service/ChatService.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/service/ChatService.java
@@ -26,8 +26,8 @@ public class ChatService {
     private final PostcardRepository postcardRepository;
     private final PushAlarmEventHandler postcardPushAlarmEventListener;
 
-    public void updatePostcardStatusByChat(EntryRequest entryRequest, PostcardStatus postcardStatus) {
-        Postcard postcard = postcardRepository.findByIdWithMembers(entryRequest.getPostcardId())
+    public void updatePostcardStatusByChat(EntryRequest entryRequest, PostcardStatus postcardStatus, Long postcardId) {
+        Postcard postcard = postcardRepository.findByIdWithMembers(postcardId)
                 .orElseThrow(() -> new BaseException(PostcardExceptionType.INVALID_POSTCARD));
 
         postcardRepository.updatePostcardStatus(postcardStatus, postcard.getId());

--- a/src/main/java/com/bookbla/americano/domain/sendbird/service/SendbirdService.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/service/SendbirdService.java
@@ -9,6 +9,7 @@ import com.bookbla.americano.domain.member.repository.entity.Member;
 import com.bookbla.americano.domain.postcard.controller.dto.response.PostcardReadResponse;
 import com.bookbla.americano.domain.sendbird.controller.dto.response.SendbirdResponse;
 import com.bookbla.americano.domain.sendbird.exception.SendbirdException;
+import org.jetbrains.annotations.NotNull;
 import org.openapitools.client.model.*;
 import org.sendbird.client.ApiClient;
 import org.sendbird.client.ApiException;
@@ -30,7 +31,7 @@ public class SendbirdService {
     private static final int USER_NOT_FOUND = 400;
     private static final String CHANNEL_TYPE = "group_channels";
     private static final String ACCEPT_STATUS = "yet";
-    private static final String MESSAGE_TYPE= "MESG";
+    private static final String MESSAGE_TYPE = "MESG";
 
 
     private final UserApi sendbirdUserApi;
@@ -74,7 +75,7 @@ public class SendbirdService {
             sendbirdUserApi.viewUserById(userId)
                     .apiToken(apiToken)
                     .execute();
-            updateSendbirdNickname(memberId,member.getMemberProfile().getName());
+            updateSendbirdNickname(memberId, member.getMemberProfile().getName());
             updateSendbirdProfileUrl(memberId, member.getMemberStyle().getProfileImageType().getImageUrl());
             return createSendbirdUserToken(member);
         } catch (ApiException e) {
@@ -189,17 +190,10 @@ public class SendbirdService {
         }
     }
 
-    public void createSendbirdMetadata(PostcardReadResponse postcardReadResponse, String channelUrl){
+    public void createSendbirdMetadata(PostcardReadResponse postcardReadResponse, String channelUrl) {
 
-        Map<String, String> metadata = new HashMap<>();
-        metadata.put("sendMemberId", postcardReadResponse.getSendMemberId().toString());
-        metadata.put("sendMemberName", postcardReadResponse.getSendMemberName());
-        metadata.put("targetMemberId", postcardReadResponse.getReceiveMemberId().toString());
-        metadata.put("targetMemberBookId", postcardReadResponse.getReceiveMemberBookId().toString());
-        metadata.put("acceptStatus", ACCEPT_STATUS);
-
-        CreateChannelMetadataData createChannelMetadataData = new CreateChannelMetadataData()
-                .metadata(metadata);
+        Map<String, String> sendbirdMetadata = createMetadata(postcardReadResponse);
+        CreateChannelMetadataData createChannelMetadataData = new CreateChannelMetadataData().metadata(sendbirdMetadata);
 
         try {
             metadataApi.createChannelMetadata(CHANNEL_TYPE, channelUrl)
@@ -210,6 +204,17 @@ public class SendbirdService {
             deleteSendbirdGroupChannel(channelUrl);
             throw new SendbirdException(e);
         }
+    }
+
+    @NotNull
+    private Map<String, String> createMetadata(PostcardReadResponse postcardReadResponse) {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("postcardId", postcardReadResponse.getPostcardId().toString());
+        metadata.put("sendMemberId", postcardReadResponse.getSendMemberId().toString());
+        metadata.put("sendMemberName", postcardReadResponse.getSendMemberName());
+        metadata.put("targetMemberId", postcardReadResponse.getReceiveMemberId().toString());
+        metadata.put("acceptStatus", ACCEPT_STATUS);
+        return metadata;
     }
 
     public void sendEntryMessage(PostcardReadResponse postcardReadResponse, String channelUrl) {

--- a/src/main/java/com/bookbla/americano/domain/sendbird/service/SendbirdService.java
+++ b/src/main/java/com/bookbla/americano/domain/sendbird/service/SendbirdService.java
@@ -217,6 +217,18 @@ public class SendbirdService {
         return metadata;
     }
 
+    public Long getSendbirdMetadata(String channelUrl){
+        try {
+            Map<String, String> postcardId = metadataApi.viewChannelMetadataByKey(CHANNEL_TYPE, channelUrl, "postcardId")
+                    .apiToken(apiToken)
+                    .execute();
+            return Long.valueOf(postcardId.get("postcardId"));
+        } catch (ApiException e) {
+            throw new SendbirdException(e);
+        }
+    }
+
+
     public void sendEntryMessage(PostcardReadResponse postcardReadResponse, String channelUrl) {
         Book book = memberBookRepository.findBookById(postcardReadResponse.getReceiveMemberBookId())
                 .orElseThrow(() -> new BaseException(MemberBookExceptionType.BOOK_NOT_FOUND));

--- a/src/test/java/com/bookbla/americano/domain/sendbird/service/ChatServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/sendbird/service/ChatServiceTest.java
@@ -35,7 +35,7 @@ class ChatServiceTest {
         MemberBookmark womanMemberBookmark = memberBookmarkRepository.save(MemberBookmark.builder().member(member).bookmarkCount(40).build());
 
         //when
-        sut.chatAccept(member.getId());
+        sut.updateBookmarkOnChatAccept(member.getId());
 
         //then
         MemberBookmark targetMemberBookmark = memberBookmarkRepository.findById(womanMemberBookmark.getId())
@@ -49,7 +49,7 @@ class ChatServiceTest {
         memberBookmarkRepository.save(MemberBookmark.builder().member(targetmember).bookmarkCount(10).build());
 
         // when & then
-        assertThatThrownBy(() -> sut.chatAccept(targetmember.getId()))
+        assertThatThrownBy(() -> sut.updateBookmarkOnChatAccept(targetmember.getId()))
                 .isInstanceOf(BaseException.class)
                 .hasMessageContaining("책갈피 개수가 부족합니다.");
     }
@@ -61,7 +61,7 @@ class ChatServiceTest {
         MemberBookmark womanMemberBookmark = memberBookmarkRepository.save(MemberBookmark.builder().member(member).bookmarkCount(40).build());
 
         //when
-        sut.chatReject(member.getId());
+        sut.updateBookmarkOnChatReject(member.getId());
 
         //then
         MemberBookmark targetMemberBookmark = memberBookmarkRepository.findById(womanMemberBookmark.getId())


### PR DESCRIPTION
## 📄 Summary

> Sendbird 메타데이터로 postcardId를 넣어, 채팅 수락/거절시 postcardId를 requset로 받아 postcard 상태 변경 및 책갈피 개수 업데이트 하도록 만들었습니다.

## 🙋🏻 More

>