### PR TITLE
hotfix: 자정이 되었을때 초대카드가 안나오는 버그 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/notification/event/PushAlarmEventHandler.java
+++ b/src/main/java/com/bookbla/americano/domain/notification/event/PushAlarmEventHandler.java
@@ -50,7 +50,12 @@ public class PushAlarmEventHandler {
         notificationClient.send(targetMember.getPushToken(), title, body);
 
         txTemplate.executeWithoutResult(it -> memberPushAlarmRepository.save(
-                MemberPushAlarm.fromPushAlarmForm(targetMember, PushAlarmForm.POSTCARD_SEND))
+                MemberPushAlarm.builder()
+                        .member(targetMember)
+                        .title(title)
+                        .body(body)
+                        .build()
+                )
         );
     }
 


### PR DESCRIPTION
## 📄 Summary

> 자정에 member_matching isInvitationCard가 true로 리셋되어 매칭정보 유무에 관계없이 초대카드가 떠야하는데, 매칭정보가 없는 경우 초대카드가 뜨지않으며 새로고침시 서버 에러가 발생하여 isInvitationCard가 true이며 매칭정보가 없을때 문제를 수정하였습니다

## 🙋🏻 More

>