### PR TITLE
feat: 사전 모집 이벤트 초대코드 추가

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberInvitationRewardResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/member/controller/dto/response/MemberInvitationRewardResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class MemberInvitationRewardResponse {
 
     private Boolean invitingRewardStatus;
-    private String invitedRewardStatus; // 초대코드 입력 안함 -> NONE, 다른 회원 초대코드 입력 -> MEMBER, 축제 코드 입력 -> FESTIVAL
+    private String invitedRewardStatus; // 초대코드 입력 안함 -> NONE, 다른 회원 초대코드 입력 -> MEMBER, 축제 코드 입력 -> FESTIVAL, 이벤트 코드 입력 -> EVENT
     private String invitedMembersGender;
 
     public static MemberInvitationRewardResponse fromInvitingRewardNotGiven(String invitedRewardStatus) {

--- a/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
+++ b/src/main/java/com/bookbla/americano/domain/member/repository/entity/MemberModal.java
@@ -45,6 +45,11 @@ public class MemberModal {
     private Boolean hasFestivalInvitationReward = Boolean.FALSE;
 
     @Builder.Default
+    @Column(length = 1)
+    @Convert(converter = BooleanToYNConverter.class)
+    private Boolean hasEventInvitationReward = Boolean.FALSE;
+
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     private InvitationStatus invitedRewardStatus = InvitationStatus.NONE;
 
@@ -93,5 +98,16 @@ public class MemberModal {
 
     public void updateFestivalInvitationToExists() {
         this.hasFestivalInvitationReward = Boolean.TRUE;
+    }
+
+    public boolean hasEventInvitationReward() {
+        return hasEventInvitationReward == Boolean.TRUE;
+    }
+    public void completeEventInvitationModal() {
+        this.hasEventInvitationReward = Boolean.FALSE;
+    }
+
+    public void updateEventInvitationToExists() {
+        this.hasEventInvitationReward = Boolean.TRUE;
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/school/repository/entity/Invitation.java
+++ b/src/main/java/com/bookbla/americano/domain/school/repository/entity/Invitation.java
@@ -23,6 +23,7 @@ import static com.bookbla.americano.domain.school.repository.entity.InvitationSt
 public class Invitation extends BaseEntity {
 
     public static final long FESTIVAL_TEMPORARY_INVITING_MEMBER_ID = 0L;
+    public static final long EVENT_TEMPORARY_INVITING_MEMBER_ID = 0L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,6 +45,13 @@ public class Invitation extends BaseEntity {
                 .invitedMemberId(invitedMemberId)
                 .invitingMemberId(FESTIVAL_TEMPORARY_INVITING_MEMBER_ID)
                 .invitationType(InvitationType.FESTIVAL)
+                .build();
+    }
+    public static Invitation fromTempEvent(Long invitedMemberId) {
+        return Invitation.builder()
+                .invitedMemberId(invitedMemberId)
+                .invitingMemberId(EVENT_TEMPORARY_INVITING_MEMBER_ID)
+                .invitationType(InvitationType.EVENT)
                 .build();
     }
 

--- a/src/main/java/com/bookbla/americano/domain/school/repository/entity/InvitationType.java
+++ b/src/main/java/com/bookbla/americano/domain/school/repository/entity/InvitationType.java
@@ -5,6 +5,7 @@ public enum InvitationType {
     MALE,
     FEMALE,
     FESTIVAL,
+    EVENT
     ;
 
 }

--- a/src/main/java/com/bookbla/americano/domain/school/service/dto/InvitationConstants.java
+++ b/src/main/java/com/bookbla/americano/domain/school/service/dto/InvitationConstants.java
@@ -1,0 +1,10 @@
+package com.bookbla.americano.domain.school.service.dto;
+
+public class InvitationConstants {
+
+    public static final String FESTIVAL_TEMPORARY_INVITATION_CODE = "JUST4YOU";
+    public static final int FESTIVAL_INVITATION_BOOKMARK = 105;
+
+    public static final String EARLY_BIRD_INVITATION_CODE = "early6bird";
+    public static final int EARLY_BIRD_INVITATION_BOOKMARK = 200;
+}

--- a/src/test/java/com/bookbla/americano/domain/school/service/InvitationServiceTest.java
+++ b/src/test/java/com/bookbla/americano/domain/school/service/InvitationServiceTest.java
@@ -275,5 +275,57 @@ class InvitationServiceTest {
             assertThat(response.getInvitedRewardStatus()).isEqualTo("FESTIVAL");
         }
     }
+    @Nested
+    class 이벤트_초대코드 {
+
+        @Test
+        void 이벤트_초대코드를_입력하면_이벤트_초대가_생성된다() {
+            Long eventInvitingMemberId = 0L;
+            Member member = memberRepository.save(스타일_등록_완료_남성_고도리);
+            memberBookmarkRepository.save(MemberBookmark.builder().member(member).build());
+            var request = new InvitationCodeEntryRequest("early6bird");
+
+            // when
+            sut.entryInvitationCode(member.getId(), request);
+
+            // then
+            Invitation invitation = invitationRepository.findByInvitedMemberId(member.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(invitation).isNotNull(),
+                    () -> assertThat(invitation.getInvitedMemberId()).isEqualTo(member.getId()),
+                    () -> assertThat(invitation.getInvitingMemberId()).isEqualTo(eventInvitingMemberId),
+                    () -> assertThat(invitation.getInvitationStatus()).isEqualTo(BOOKMARK),
+                    () -> assertThat(invitation.getInvitationType()).isEqualTo(EVENT)
+            );
+        }
+
+        @Test
+        void 이벤트_초대코드를_입력하면_책갈피를_지급한다() {
+            Member member = memberRepository.save(스타일_등록_완료_남성_고도리);
+            MemberBookmark memberBookmark = memberBookmarkRepository.save(MemberBookmark.builder().member(member).build());
+            var request = new InvitationCodeEntryRequest("early6bird");
+
+            // when
+            sut.entryInvitationCode(member.getId(), request);
+
+            // then
+            assertThat(memberBookmark.getBookmarkCount()).isEqualTo(200);
+        }
+
+        @Test
+        void 이벤트_초대코드를_입력했다면_invitedRewardStatus는_EVENT이다() {
+            // given
+            Member man = memberRepository.save(프로필_등록_완료_여성_김밤비);
+            memberBookmarkRepository.save(MemberBookmark.builder().member(man).build());
+            sut.entryInvitationCode(man.getId(), new InvitationCodeEntryRequest("early6bird"));
+
+            // when
+            MemberInvitationRewardResponse response = sut.getInvitationRewardStatus(man.getId());
+
+            // then
+            assertThat(response.getInvitingRewardStatus()).isFalse();
+            assertThat(response.getInvitedRewardStatus()).isEqualTo("EVENT");
+        }
+    }
 }
 


### PR DESCRIPTION
## 📄 Summary

> 이번 사전 모집에 사용할 얼리버드 초대코드를 이벤트 코드로 추가하므로써 기존 축제 코드와 분리하여 작성함
> 앞으로 다양한 축제와 이벤트가 열릴 것으로 보아 축제와 이벤트 관련 초대코드 및 책갈피 보상을 상수클래스(InvitationConstants)에 모아 작성함

## 🙋🏻 More

>