### PR TITLE
fix: matched_info 정보를 member_matching에 업데이트 하는 부분을 refresh에서 하게끔 수정

### DIFF
--- a/src/main/java/com/bookbla/americano/domain/matching/controller/dto/response/MemberIntroResponse.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/controller/dto/response/MemberIntroResponse.java
@@ -61,12 +61,12 @@ public class MemberIntroResponse {
                 .build();
     }
 
-    @Override
-    public boolean equals(Object o) {
+    public boolean equalsShowInvitationCard(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MemberIntroResponse that = (MemberIntroResponse) o;
 
-        return Objects.equals(isInvitationCard, that.isInvitationCard);
+        return Objects.equals(isInvitationCard, that.isInvitationCard)
+                && Objects.equals(memberId, that.memberId);
     }
 }

--- a/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
+++ b/src/main/java/com/bookbla/americano/domain/matching/service/MemberMatchingService.java
@@ -62,8 +62,6 @@ public class MemberMatchingService {
             if (matchedInfo == null) {
                 return MemberIntroResponse.empty();
             }
-            updateCurrentMatchedInfo(memberMatching, matchedInfo.getMatchedMemberId(), matchedInfo.getMatchedMemberBookId());
-            memberMatching.updateInvitationCard(false);
             return buildMemberIntroResponseWithMatchedInfo(matchedInfo, memberMatching);
         }
 
@@ -106,12 +104,14 @@ public class MemberMatchingService {
         if (!memberMatching.hasCurrentMatchedInfo() && memberMatching.getIsInvitationCard()) {
             MemberIntroResponse memberIntroResponse = getHomeMatch(memberId);
 
-            if (memberIntroResponse.equals(MemberIntroResponse.showInvitationCard())) { // null null true + matched_info 없음
+            if (memberIntroResponse.equalsShowInvitationCard(MemberIntroResponse.showInvitationCard())) { // null null true + matched_info 없음
                 memberMatching.updateInvitationCard(false);
                 return MemberIntroResponse.empty();
             }
             // null null true + matched_info 존재
-            return memberIntroResponse;
+            updateCurrentMatchedInfo(memberMatching, memberIntroResponse.getMemberId(), memberIntroResponse.getMemberBookId());
+            memberMatching.updateInvitationCard(false);
+            return buildMemberIntroResponseWithMemberIntroResponse(memberIntroResponse, memberMatching);
         }
 
         // value value false + matched_info 존재 & value value false + matched_info 없음


### PR DESCRIPTION
## 📄 Summary

> matched_info 정보를 getHomeMatch()에서 member_matching에 업데이트하니 또 다른 페이지 갔다왔을때 초대카드가 없어지는 문제 발생하여  refreshMemberMatching()에서 하게끔 수정 
## 🙋🏻 More

>